### PR TITLE
dynamic_menu - add_multiple_items

### DIFF
--- a/release/include/dynamic_menu.nvgt
+++ b/release/include/dynamic_menu.nvgt
@@ -42,6 +42,15 @@ class dynamic_menu {
 		return add_item_extended(text, false, name);
 	}
 
+	int[] add_multiple_items(string[][] items){
+		int[] res;
+		for (uint i = 0; i < items.length(); i++){
+			string text = items[i][0], name = items[i].length() > 1 ? items[i][1] : "";
+			res.insert_last(add_item_extended(text, false, name));
+		}
+	return res;
+}
+
 	bool set_speech_mode(int speech_output) {
 		if ((speech_output < 0) || (speech_output > 4))
 			return false;


### PR DESCRIPTION
Adds a new function to dynamic_menu (add_multiple_items) that accepts an array of arrays. Each subarray must have at least 1 element. The first element is the text, the second element is the name. For example,

dynamic_menu newmenu;
newmenu.add_multiple_items({{"start game"}, {"end game"}});

Due to the angelscript restrictions, this was the closest I could get to having it be flexible. The original intent was to let regular strings be used for only the text if the developer wanted, and string arrays be used when both text and name need to be specified, but that was not possible.