### PR TITLE
Fixed Wrong Spellings Of Voide in parse_float.nvgt

### DIFF
--- a/src/angelscript.cpp
+++ b/src/angelscript.cpp
@@ -76,6 +76,7 @@
 #include "scripthandle.h"
 #include "scripthelper.h"
 #include "scriptmath.h"
+#include "scriptmathcomplex.h"
 #include "contextmgr.h"
 #include "datetime.h"
 #include "weakref.h"
@@ -337,6 +338,7 @@ int ConfigureEngine(asIScriptEngine* engine) {
 	RegisterScriptGrid(engine);
 	RegisterScriptHandle(engine);
 	RegisterScriptMath(engine);
+	RegisterScriptMathComplex(engine);
 	RegisterScriptWeakRef(engine);
 	engine->SetDefaultAccessMask(NVGT_SUBSYSTEM_TERMINAL);
 	Print::asRegister(engine);

--- a/test/case/parse_float.nvgt
+++ b/test/case/parse_float.nvgt
@@ -1,3 +1,3 @@
-voide test_parse_float() {
+void test_parse_float() {
 assert(parse_float("1.0") == 1.0);
 }


### PR DESCRIPTION
In /test/case/parse_float.nvgt, the function had voide data type, which was incorrect. I have fixed that.