### PR TITLE
Create workflow for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,5 @@
 name: nightly_build
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   mac_build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: windows_package_build
-        path: install/nvgt_${{ env.version }}_${{ env.build_time }}.exe
+        path: nvgt_${{ env.version }}_${{ env.build_time }}.exe
 
   mac_package:
     runs-on: macos-latest
@@ -149,7 +149,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: mac_package
-        path: install/nvgt_${{ env.version }}_${{ env.build_time }}.dmg
+        path: nvgt_${{ env.version }}_${{ env.build_time }}.dmg
 
   linux_package:
     runs-on: ubuntu-latest
@@ -196,4 +196,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: linux_package
-        path: release/nvgt_${{ env.version }}_${{ env.build_time }}.tar.gz
+        path: nvgt_${{ env.version }}_${{ env.build_time }}.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,191 @@
+name: nightly_build
+on:
+  push:
+
+jobs:
+  mac_build:
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+    - name: build
+      run: |
+        brew install scons
+        cp build/build_macos.sh .
+        sudo chmod +x build_macos.sh
+        ./build_macos.sh ci
+        cd release
+        tar -czf ../mac_release.tar.gz *
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: mac_release
+        path: mac_release.tar.gz
+
+  linux_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: build
+      run: |
+        sudo chmod +x build/build_linux.sh
+        ./build/build_linux.sh ci
+        python3 build/ci_set_version.py
+        cd release
+        tar -czf ../linux_release.tar.gz *
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux_release
+        path: linux_release.tar.gz
+
+  windows_build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: build
+      run: |
+        pip3 install scons
+        choco install -y upx
+        curl -s -O https://nvgt.gg/windev.zip
+        7z x windev.zip -owindev
+        scons -s
+        cd release
+        tar -czf ../windows_release.tar.gz *
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows_release
+        path: windows_release.tar.gz
+
+  windows_package:
+    runs-on: windows-latest
+    needs: ["linux_build", "mac_build", "windows_build"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: linux_release
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: mac_release
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows_release
+    - name: package
+      shell: bash
+      run: |
+        mkdir linux_release
+        tar -xzf linux_release.tar.gz -C linux_release
+        mkdir mac_release
+        tar -xzf mac_release.tar.gz -C mac_release
+        tar -xzf windows_release.tar.gz -C release
+        cd doc
+        pip3 install -r requirements.txt
+        cd OSL
+        python3 make_osl_document.py
+        cd ..
+        python3 docgen.py
+        cd ..
+        cp linux_release/stub/* release/stub
+        cp mac_release/stub/* release/stub
+        cd install
+        makensis nvgt.nsi
+        version=$(cat ../version)
+        build_time=$(TZ=UTC date +'%Y-%m-%d-%H:%M:%S')
+        mv nvgt_*.exe nvgt_${version}_$build_time.exe
+    - name: Upload packaged build
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows_package_build
+        path: install/nvgt_${version}_$build_time.exe
+
+  mac_package:
+    runs-on: macos-latest
+    needs: ["linux_build", "mac_build", "windows_build"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: linux_release
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows_release
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: mac_release
+    - name: package
+      run: |
+        mkdir linux_release
+        tar -xzf linux_release.tar.gz -C linux_release
+        mkdir windows_release
+        tar -xzf windows_release.tar.gz -C windows_release
+        tar -xzf mac_release.tar.gz -C release
+        cd doc
+        pip3 install --user -r requirements.txt --break-system-packages
+        cd OSL
+        python3 make_osl_document.py
+        cd ..
+        python3 docgen.py
+        cd ..
+        cp linux_release/stub/* release/stub
+        cp windows_release/stub/* release/stub
+        cd install
+        python3 make_dmg.py ../release
+        version=$(cat ../version)
+        build_time=$(TZ=UTC date +'%Y-%m-%d-%H:%M:%S')
+        mv nvgt_*.dmg nvgt_${version}_$build_time.dmg
+    - name: Upload package
+      uses: actions/upload-artifact@v4
+      with:
+        name: mac_package
+        path: install/nvgt_${version}_$build_time.dmg
+
+  linux_package:
+    runs-on: ubuntu-latest
+    needs: ["linux_build", "mac_build", "windows_build"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: linux_release
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows_release
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: mac_release
+    - name: package
+      run: |
+        mkdir mac_release
+        tar -xzf mac_release.tar.gz -C mac_release
+        mkdir windows_release
+        tar -xzf windows_release.tar.gz -C windows_release
+        tar -xzf linux_release.tar.gz -C release
+        cd doc
+        pip3 install --user -r requirements.txt
+        cd OSL
+        python3 make_osl_document.py
+        cd ..
+        python3 docgen.py
+        cd ..
+        cp mac_release/stub/* release/stub
+        cp windows_release/stub/* release/stub
+        cd release
+        version=$(cat ../version)
+        build_time=$(TZ=UTC date +'%Y-%m-%d-%H:%M:%S')
+        tar -czf "nvgt.tar.gz" *
+        mv nvgt.tar.gz nvgt_${version}_$build_time.tar.gz
+    - name: Upload packaged build
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux_package
+        path: release/nvgt_${version}_$build_time.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,6 +74,7 @@ jobs:
       with:
         name: windows_release
     - name: package
+      id: package_step
       shell: bash
       run: |
         mkdir linux_release
@@ -94,12 +95,14 @@ jobs:
         makensis nvgt.nsi
         version=$(cat ../version)
         build_time=$(TZ=UTC date +'%Y-%m-%d-%H:%M:%S')
+        echo "version=$version" >> $GITHUB_ENV
+        echo "build_time=$build_time" >> $GITHUB_ENV
         mv nvgt_*.exe nvgt_${version}_$build_time.exe
     - name: Upload packaged build
       uses: actions/upload-artifact@v4
       with:
         name: windows_package_build
-        path: install/nvgt_${version}_$build_time.exe
+        path: install/nvgt_${{ env.version }}_${{ env.build_time }}.exe
 
   mac_package:
     runs-on: macos-latest
@@ -119,6 +122,7 @@ jobs:
       with:
         name: mac_release
     - name: package
+      id: package_step
       run: |
         mkdir linux_release
         tar -xzf linux_release.tar.gz -C linux_release
@@ -138,12 +142,14 @@ jobs:
         python3 make_dmg.py ../release
         version=$(cat ../version)
         build_time=$(TZ=UTC date +'%Y-%m-%d-%H:%M:%S')
+        echo "version=$version" >> $GITHUB_ENV
+        echo "build_time=$build_time" >> $GITHUB_ENV
         mv nvgt_*.dmg nvgt_${version}_$build_time.dmg
     - name: Upload package
       uses: actions/upload-artifact@v4
       with:
         name: mac_package
-        path: install/nvgt_${version}_$build_time.dmg
+        path: install/nvgt_${{ env.version }}_${{ env.build_time }}.dmg
 
   linux_package:
     runs-on: ubuntu-latest
@@ -163,6 +169,7 @@ jobs:
       with:
         name: mac_release
     - name: package
+      id: package_step
       run: |
         mkdir mac_release
         tar -xzf mac_release.tar.gz -C mac_release
@@ -181,10 +188,12 @@ jobs:
         cd release
         version=$(cat ../version)
         build_time=$(TZ=UTC date +'%Y-%m-%d-%H:%M:%S')
+        echo "version=$version" >> $GITHUB_ENV
+        echo "build_time=$build_time" >> $GITHUB_ENV
         tar -czf "nvgt.tar.gz" *
         mv nvgt.tar.gz nvgt_${version}_$build_time.tar.gz
     - name: Upload packaged build
       uses: actions/upload-artifact@v4
       with:
         name: linux_package
-        path: release/nvgt_${version}_$build_time.tar.gz
+        path: release/nvgt_${{ env.version }}_${{ env.build_time }}.tar.gz


### PR DESCRIPTION
This uses a verry similar workflow to the release one, but it gets triggered on each push or new pull request to create nightly builds of the engine. All builds get built, packaged and uploaded to GH Artephacts for use with a service such as nightly.link or individual downloads.