### PR TITLE
filled out most of the documentation for tts_voice class methods. Pit…

### DIFF
--- a/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/get_speaking.nvgt
+++ b/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/get_speaking.nvgt
@@ -1,0 +1,15 @@
+/**
+	Check if the text to speech voice is currently speaking.
+	bool tts_voice::get_speaking();
+	## Returns:
+		* bool: whether the tts voice is speaking. True if so, false if not.
+*/
+
+// Example:
+void main() {
+	tts_voice v;
+	alert("Is it speaking right now?", v.get_speaking());
+	v.speak("I'm now saying something, I think...");
+	wait(250);
+	alert("How about now?", v.get_speaking());
+}

--- a/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/get_voice_count.nvgt
+++ b/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/get_voice_count.nvgt
@@ -1,0 +1,14 @@
+/**
+	Get a count of all available text to speech voices, including the builtin.
+	int tts_voice::get_voice_count();
+	## Returns:
+		* int: the number of tts voices.
+	## Remarks:
+		The default voice built into Nvgt is counted here so it's always one more than the available system voices.
+*/
+
+// Example:
+void main() {
+	tts_voice v;
+	alert("result:", "You have "+v.get_voice_count()+" voices");
+}

--- a/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/get_volume.nvgt
+++ b/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/get_volume.nvgt
@@ -1,0 +1,15 @@
+/**
+	Get the text to speech voice's volume (how loud it is).
+	int tts_voice::get_volume();
+	## Returns:
+		int: the current volume in percentage.
+	## Remarks:
+		0 is silent, 100 is louded. If this hasn't been assigned, it will use the OS setting which may not be 100%. Beware if running old code, this is different from bgt having 0 be the max.
+*/
+
+// Example:
+void main() {
+	tts_voice v;
+	v.set_volume(50);
+	alert("the current volume is: ", ""+v.get_volume());
+}

--- a/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/set_rate.nvgt
+++ b/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/set_rate.nvgt
@@ -1,0 +1,22 @@
+/**
+	Set the text to speech voice's playback rate (how fast it speaks).
+	void tts_voice::set_rate(int rate);
+	## Arguments:
+		* int rate: the desired speech rate.
+	## Remarks:
+		-10 is slowest, 10 is fastest, with 0 being default speed, or 50 percent if you like. If this hasn't been manually assigned, it will use the OS setting which may not be 0. If moving in old bgt code, you may want to update it to use this method instead of the rate property.
+*/
+
+// Example:
+void main() {
+	tts_voice v;
+	v.set_rate(0);
+	v.speak("This is at fifty percent rate");
+	v.set_rate(5);
+	v.speak_wait("this is at seventy-five percent rate");
+	//demonstrate setting it like it's a percentage, but note that it'll jump a bit because percentages have 100 values but there are only technically 21 choices, so implement this idea with an increment of 5 for best results.
+	uint desired_rate=85;
+	v.set_rate(desired_rate/5-10);
+	int resulting_rate=v.get_rate();
+	alert("after setting as 85 percent, the resulting rate now is:", resulting_rate);
+}

--- a/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/set_volume.nvgt
+++ b/doc/src/references/builtin/Text-To-Speech/classes/tts_voice/Methods/set_volume.nvgt
@@ -1,0 +1,17 @@
+/**
+	Set the text to speech voice's volume (how loud it is).
+	void tts_voice::set_volume(int volume);
+	## Arguments:
+		* int volume: the desired volume level.
+	## Remarks:
+		0 is silent, 100 is louded. If this hasn't been assigned, it will use the OS setting which may not be 100%. Beware if running old code, this is different from bgt having 0 be the max. It's better to use this instead of directly setting volume property.
+*/
+
+// Example:
+void main() {
+	tts_voice v;
+	v.set_volume(50);
+	v.speak("This is at 50 volume");
+	v.set_volume(100);
+	v.speak_wait("this is at 100 volume");
+}


### PR DESCRIPTION
…ch is omitted because it doesn't work and speak_interrupt_wait while registered doesn't have an actual method apparently.