### PR TITLE
Form modifications

### DIFF
--- a/release/include/form.nvgt
+++ b/release/include/form.nvgt
@@ -576,7 +576,7 @@ class audio_form {
 			if (subform)
 				return 2;
 		}
-		if ((focused < 0 || c_form[focused].type != ct_keyboard_area) && (focused < 0 || (c_form[focused].multiline == false) || (c_form[focused].multiline_enter == false && (key_up(KEY_LCTRL)) && (key_up(KEY_RCTRL)) && (key_up(KEY_LSHIFT)) && (key_up(KEY_RSHIFT)))) && ((key_pressed(KEY_RETURN)) || (key_pressed(KEY_NUMPAD_ENTER)) || (autotab == 3))) {
+		if ((focused < 0 || c_form[focused].type != ct_keyboard_area) && (focused < 0 || ((c_form[focused].multiline_enter && c_form[focused].multiline && c_form[focused].type == ct_input || c_form[focused].type == ct_button) && (key_up(KEY_LCTRL)) && (key_up(KEY_RCTRL)) && (key_up(KEY_LSHIFT)) && (key_up(KEY_RSHIFT)))) && ((key_pressed(KEY_RETURN)) || (key_pressed(KEY_NUMPAD_ENTER)) || (autotab == 3))) {
 			stop_speech();
 			if ((defaults == -1) && (focused > -1)) {
 				if (c_form[focused].type == ct_button)
@@ -2247,8 +2247,6 @@ class control {
 		focused = true;
 	}
 	void check(audio_form@ f, int tab_index) {
-		if (type == ct_keyboard_area)
-			return;
 		string char;
 		char = get_characters();
 		if ((type == ct_input) && key_up(KEY_LALT) && (focused)) {
@@ -2771,6 +2769,8 @@ class control {
 			speak(selection + " " + highlight_selection_speech_text, true, false);
 	}
 	void add(string character, bool silent = false) {
+		if(type != ct_input)
+		return;
 		string new_text = text;
 		if (sel_start > -1 && sel_end > -1) {
 			cursor = sel_start;


### PR DESCRIPTION
The following modifications were made:
* Changed key_return pressure so that it could work well in games where this key is also checked, causing conflict.
* Added a check in void add to check if the type of the control is ct_input, otherwise it returns.
* The verification in void check of whether the control was ct_keyboard_area and then launching return was eliminated, this so that the above was verified.