### PR TITLE
Documentation of audio_form and token_gen

### DIFF
--- a/doc/src/references/include/Auditory User Interface (form.nvgt)/Classes/audio_form/Methods/set_disallowed_chars.md
+++ b/doc/src/references/include/Auditory User Interface (form.nvgt)/Classes/audio_form/Methods/set_disallowed_chars.md
@@ -1,0 +1,18 @@
+# set_disallowed_chars
+Sets the whitelist/blacklist characters of a control.
+
+`bool audio_form::set_disallowed_chars(int control_index, string chars, bool use_only_disallowed_chars = false, string char_disallowed_description = "");`
+
+## Arguments:
+* int control_index: the index of the control.
+* string chars: the characters to set.
+* bool use_only_disallowed_chars = false: sets whether the control should only use the characters in this list. true means use only characters that are in the list, and false means allow only characters that are not in the list.
+* string char_disallowed_description = "": the text to speak when an invalid character is inputted.
+
+## Returns:
+bool: true if the characters were successfully set, false otherwise.
+
+## Remarks:
+Setting the use_only_disallowed_chars parameter to true will restrict all characters that are not in the list. This is useful to prevent other characters in number inputs.
+
+Setting the chars parameter to blank will clear the characters and will switch back to default.

--- a/doc/src/references/include/Auditory User Interface (form.nvgt)/Classes/audio_form/Methods/set_enable_go_to_index.md
+++ b/doc/src/references/include/Auditory User Interface (form.nvgt)/Classes/audio_form/Methods/set_enable_go_to_index.md
@@ -1,0 +1,11 @@
+# set_enable_go_to_index
+Toggles whether the control can use go to line functionality.
+
+`bool audio_form::set_enable_go_to_index(int control_index, bool enabled);`
+
+## Arguments:
+* int control_index: the index of the control.
+* bool enabled: enables the go to line functionality.
+
+## Returns:
+bool: true if the state was successfully set, false otherwise.

--- a/doc/src/references/include/Token Generation (token_gen.nvgt)/!token_gen.md
+++ b/doc/src/references/include/Token Generation (token_gen.nvgt)/!token_gen.md
@@ -1,2 +1,2 @@
 # Token generation include
-Allows you to easily generate random strings of characters of any length.
+Allows you to easily generate random strings of characters of any length in a given mode.

--- a/doc/src/references/include/Token Generation (token_gen.nvgt)/Enums/token_gen_flag {.md
+++ b/doc/src/references/include/Token Generation (token_gen.nvgt)/Enums/token_gen_flag {.md
@@ -1,0 +1,9 @@
+# token_gen_flag {
+This enum holds various constants that can be passed to the mode parameter in order to change how tokens are generated.
+
+* token_gen_flag_all: Uses all characters, numbers and symbols, see below.
+* token_gen_flag_characters: Uses only characters, a-z, A-Z
+* token_gen_flag_numbers: Uses only numbers, 0-9
+* token_gen_flag_symbols: Uses only symbols, \`\~\!\@\#\$\%\^\&\*\(\)\_\+\=\-\[\]\{\}\/\.\,\;\:\|\?\>\<\ 
+* token_gen_flag_numbers_symbols: Uses numbers and symbols.
+* token_gen_flag_characters_symbols: Uses characters and symbols.

--- a/doc/src/references/include/Token Generation (token_gen.nvgt)/Enums/token_gen_flag.md
+++ b/doc/src/references/include/Token Generation (token_gen.nvgt)/Enums/token_gen_flag.md
@@ -1,4 +1,4 @@
-# token_gen_flag {
+# token_gen_flag
 This enum holds various constants that can be passed to the mode parameter in order to change how tokens are generated.
 
 * token_gen_flag_all: Uses all characters, numbers and symbols, see below.

--- a/doc/src/references/include/Token Generation (token_gen.nvgt)/Functions/generate_token.nvgt
+++ b/doc/src/references/include/Token Generation (token_gen.nvgt)/Functions/generate_token.nvgt
@@ -1,12 +1,13 @@
 /**
 	Generates a string of random characters, or token.
-	string generate_token(int token_length)
+	string generate_token(int token_length, int mode = token_gen_flag_all)
 	## Arguments:
 		* int token_length: the length of the token to generate.
+		* int mode = token_gen_flag_all: the mode to generate.
 	## returns:
-		String: a random token.
+		String: a random token depending on the mode.
 	## Remarks:
-		The characters used to generate the token are: "1234567890abcdefthijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".
+		The characters used to generate the token will depend on the mode you set. See `token_gen_flags` enum constants.
 */
 
 // Example:
@@ -14,4 +15,6 @@
 
 void main() {
 	alert("Info", "Your token is: " + generate_token(10));
+	alert("Info", "Numbers only token is: " + generate_token(10, token_gen_flag_numbers));
+	alert("Info", "Characters only token is: " + generate_token(10, token_gen_flag_characters));
 }


### PR DESCRIPTION
* Documentation for Token Gen has been updated, including its enum constants.
* Audio Form documentation: `set_enable_go_to_index`, and `set_disallowed_chars`.