### PR TITLE
Form: Fixed the issue with column when it is used in single line inputs

### DIFF
--- a/release/include/form.nvgt
+++ b/release/include/form.nvgt
@@ -2752,6 +2752,7 @@ class control {
 			return false;
 		}
 		if (col > max_col) col = max_col;
+		if (pos==0) col--;
 		pos += col;
 		cursor = pos;
 		sel_start = -1;


### PR DESCRIPTION
This issue is produced only on line 1 where it sets the column minus instead of how it should be.

For example, the issue was, it sets the column to 3 when we set to 4, etc. And so the issue has been resolved.