### PR TITLE
Fixed language detection issue in copy.js

### DIFF
--- a/web/src/js/copy.js
+++ b/web/src/js/copy.js
@@ -8,7 +8,7 @@ document.querySelectorAll("pre").forEach(pre => {
 	// Extract the language from <pre>"s data-lang or <code>"s class
 	let language = pre.getAttribute("data-lang");
 	if (!language && codeBlock && codeBlock.className) {
-		const match = codeBlock.className.match( / language - (\w +) /);
+		const match = codeBlock.className.match(/language-(\w+)/);
 		language = match ? match[1] : "";
 	}
 	// If language is found, create and insert a language label


### PR DESCRIPTION
Previously @braillescreen formatted the code with spaces in the language area, which should not be done, because Cobalt generate `<pre><code class="language-NVGT"></code></pre>`, which is no space. Other formatted areas are left untouched.