### PR TITLE
Includes improvements

### DIFF
--- a/release/include/form.nvgt
+++ b/release/include/form.nvgt
@@ -721,17 +721,7 @@ class audio_form {
 			form_error = form_error_invalid_control;
 			return false;
 		}
-		if (char.length() < 1) {
-			form_error = form_error_invalid_value;
-			return false;
-		}
-		if (search_all) {
-			for (uint i = 0; i < char.length(); i++) {
-				if (c_form[control_index].disallowed_chars.find(char[i]) < 0) return false;
-			}
-			return true;
-		}
-		return c_form[control_index].disallowed_chars.find(char) > -1;
+		return c_form[control_index].is_disallowed_char(char, search_all);
 	}
 	bool is_visible(int control_index) {
 		form_error = 0;
@@ -2578,11 +2568,12 @@ class control {
 			return false;
 		if (search_all) {
 			for (uint i = 0; i < char.length(); i++) {
-				if (this.disallowed_chars.find(char[i]) < 0) return false;
+				if (this.disallowed_chars.find(char[i]) < 0 && this.use_only_disallowed_chars) return true;
+				else if (this.disallowed_chars.find(char[i]) > -1 && !this.use_only_disallowed_chars) return true;
 			}
-			return true;
+			return false;
 		}
-		return this.disallowed_chars.find(char) > -1;
+		return (this.disallowed_chars.find(char) > -1 && !this.use_only_disallowed_chars) or (this.disallowed_chars.find(char) < 0 && this.use_only_disallowed_chars);
 	}
 	void check(audio_form@ f, int tab_index) {
 		string char;
@@ -2590,14 +2581,9 @@ class control {
 		if ((type == ct_input) && key_up(KEY_LALT) && (focused)) {
 			if (!read_only) {
 				if (char != "") {
-					if (this.disallowed_chars.length() > 0) {
-						if (this.use_only_disallowed_chars && !this.is_disallowed_char(char)) {
-							if (this.char_disallowed_description != "") speak(this.char_disallowed_description);
-							return;
-						} else if (!this.use_only_disallowed_chars && this.is_disallowed_char(char)) {
-							if (this.char_disallowed_description != "") speak(this.char_disallowed_description);
-							return;
-						}
+					if (this.disallowed_chars.length() > 0 && this.is_disallowed_char(char)) {
+						if (this.char_disallowed_description != "") speak(this.char_disallowed_description);
+						return;
 					}
 					if (overwrite)
 						edit(char);
@@ -3282,6 +3268,10 @@ class control {
 		}
 		if ((max_length > 0) && ((text + paste).length() - (sel_end - sel_start) > max_length)) {
 			speak("clipboard data can't fit", true);
+			return;
+		}
+		if (this.disallowed_chars.length() > 0 && this.is_disallowed_char(paste)) {
+			if (this.char_disallowed_description != "") speak(this.char_disallowed_description);
 			return;
 		}
 		string new_text = text;

--- a/release/include/settings.nvgt
+++ b/release/include/settings.nvgt
@@ -19,7 +19,6 @@
  * 3. This notice may not be removed or altered from any source distribution.
 */
 
-#include"bgt_compat.nvgt" //the INI include requires this include.
 #include"ini.nvgt"
 class settings_helper {
 	string company_name, product;
@@ -107,7 +106,7 @@ class ini_settings_helper: settings_helper {
 		tempfile.open(filepath, "rb");
 		string final_data = tempfile.read();
 		tempfile.close();
-		if (this.encrypt_data) final_data = string_decrypt(final_data, this.encryption_key);
+		if (this.encrypt_data) final_data = string_aes_decrypt(final_data, this.encryption_key);
 		bool loaded = this.config.load_string(final_data, filepath);
 		return loaded;
 	}
@@ -145,7 +144,7 @@ class ini_settings_helper: settings_helper {
 		string final_data = this.config.dump();
 		file tempfile;
 		if (!tempfile.open(filepath, "wb")) return false;
-		if (this.encrypt_data) final_data = string_encrypt(final_data, this.encryption_key);
+		if (this.encrypt_data) final_data = string_aes_encrypt(final_data, this.encryption_key);
 		tempfile.write(final_data);
 		tempfile.close();
 		return true;
@@ -175,7 +174,7 @@ class json_settings_helper: settings_helper {
 		tempfile.open(filepath, "rb");
 		string final_data = tempfile.read();
 		tempfile.close();
-		if (this.encrypt_data) final_data = string_decrypt(final_data, this.encryption_key);
+		if (this.encrypt_data) final_data = string_aes_decrypt(final_data, this.encryption_key);
 		@this.config = parse_json(final_data);
 		return true;
 	}
@@ -210,7 +209,7 @@ class json_settings_helper: settings_helper {
 		file tempfile;
 		if (!tempfile.open(this.get_data_path(), "wb")) return false;
 		string final_data = this.config.stringify();
-		if (this.encrypt_data) final_data = string_encrypt(final_data, this.encryption_key);
+		if (this.encrypt_data) final_data = string_aes_encrypt(final_data, this.encryption_key);
 		tempfile.write(final_data);
 		tempfile.close();
 		return true;
@@ -239,7 +238,7 @@ class nvgt_settings_helper: settings_helper {
 		file tempfile;
 		tempfile.open(filepath, "rb");
 		string final_data = tempfile.read();
-		if (this.encrypt_data) final_data = string_decrypt(final_data, this.encryption_key);
+		if (this.encrypt_data) final_data = string_aes_decrypt(final_data, this.encryption_key);
 		@this.config = deserialize(final_data);
 		tempfile.close();
 		return true;
@@ -283,7 +282,7 @@ class nvgt_settings_helper: settings_helper {
 		file tempfile;
 		if (!tempfile.open(this.get_data_path(), "wb")) return false;
 		string final_data = this.config.serialize();
-		if (this.encrypt_data) final_data = string_encrypt(final_data, this.encryption_key);
+		if (this.encrypt_data) final_data = string_aes_encrypt(final_data, this.encryption_key);
 		tempfile.write(final_data);
 		tempfile.close();
 		return true;

--- a/test/interact/formtest.nvgt
+++ b/test/interact/formtest.nvgt
@@ -7,6 +7,12 @@ void main() {
 	audio_form f;
 	f.create_window("test");
 	int b = f.create_input_box("type text here", "or leave it alone");
+	//Disallow characters field
+	int c = f.create_input_box("Text without spaces and quotes");
+	f.set_disallowed_chars(c, " \"", false, "Spaces and quotes are not allowed");
+	//Disallow characters field but only given characters can be typed.
+	int d = f.create_input_box("Type numbers only (0-9)");
+	f.set_disallowed_chars(d, "1234567890", true, "Only digits");
 	int ok = f.create_button("ok", true);
 	while (!key_pressed(KEY_ESCAPE)) {
 		wait(5);
@@ -14,4 +20,5 @@ void main() {
 		if (f.is_pressed(ok))
 			speak(f.get_text(b), true);
 	}
+	exit();
 }


### PR DESCRIPTION
* The `form::is_disallowed_char` method will now always return true if the character is not allowed. This also automatically checks whether the control index is being used as either blacklist or whitelist, the `use_only_disallowed_characters` parameter.
* Pasting text will now fail if the clipboard contains disallowed characters.
* The settings.nvgt no longer requires bgt_compat.