### PR TITLE
fixed a typo and added in some typedefs

### DIFF
--- a/release/include/bgt_compat.nvgt
+++ b/release/include/bgt_compat.nvgt
@@ -1,4 +1,4 @@
-/* bgt_compat.nvgt - bgt compatibility layher
+/* bgt_compat.nvgt - bgt compatibility layer
  *
  * NVGT - NonVisual Gaming Toolkit
  * Copyright (c) 2022-2024 Sam Tupy
@@ -356,3 +356,8 @@ const uint KEY_LBRACKET = KEY_LEFTBRACKET;
 const uint KEY_RBRACKET = KEY_RIGHTBRACKET;
 const uint KEY_NUMPADENTER = KEY_NUMPAD_ENTER;
 const uint KEY_DASH = KEY_MINUS;
+
+typedef int long;
+typedef uint ulong;
+typedef int16 short;
+typedef uint16 ushort;


### PR DESCRIPTION
I just added some typedefs for some int types that I saw bgt had, which improves backwards compatability. There is no reason to have them in the main part of the engine, at least in my opinion, but they fit here. Also fixed a typo.