### PR TITLE
Update event constant names to reflect actual variable names

### DIFF
--- a/doc/src/references/builtin/Networking/Constants/Event Types.md
+++ b/doc/src/references/builtin/Networking/Constants/Event Types.md
@@ -1,7 +1,8 @@
 # Event Types
+
 This is a list of all the constants supported as event types by NVGT's networking layer.
 
-* event_type_none: no event.
-* event_type_connect: a new user wants to connect.
-* event_type_disconnect: a user wants to disconnect.
-* event_type_receive: a user sent a packet.
+- event_none: no event.
+- event_connect: a new user wants to connect.
+- event_disconnect: a user wants to disconnect.
+- event_receive: a user sent a packet.


### PR DESCRIPTION
This PR aims to improve the current documentation by correcting the event type constant names. Basically, it removes the "_type" portion of the name, so, e.g., "event_type_none" becomes "event_none".