### PR TITLE
An Attempt to Fix get_characters on Android

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -527,6 +527,18 @@ CScriptArray* query_touch_device(uint64_t device_id) {
 	return array;
 }
 
+bool StartTextInput() {
+	return SDL_StartTextInput(g_WindowHandle);
+}
+
+bool StopTextInput() {
+	return SDL_StopTextInput(g_WindowHandle);
+}
+
+bool TextInputActive() {
+	return SDL_TextInputActive(g_WindowHandle);
+}
+
 void RegisterInput(asIScriptEngine* engine) {
 	engine->RegisterObjectType("touch_finger", sizeof(SDL_Finger), asOBJ_VALUE | asOBJ_POD | asGetTypeTraits<SDL_Finger>());
 	engine->RegisterObjectProperty("touch_finger", "const uint64 id", asOFFSET(SDL_Finger, id));
@@ -540,6 +552,9 @@ void RegisterInput(asIScriptEngine* engine) {
 	engine->RegisterEnum(_O("joystick_bind_type"));
 	engine->RegisterEnum(_O("joystick_power_level"));
 	engine->RegisterEnum(_O("joystick_control_type"));
+	engine->RegisterGlobalFunction(_O("bool start_text_input()"), asFUNCTION(StartTextInput), asCALL_CDECL);
+	engine->RegisterGlobalFunction(_O("bool stop_text_input()"), asFUNCTION(StopTextInput), asCALL_CDECL);
+	engine->RegisterGlobalFunction(_O("bool text_input_active()"), asFUNCTION(TextInputActive), asCALL_CDECL);
 	engine->RegisterGlobalFunction(_O("bool get_KEYBOARD_AVAILABLE() property"), asFUNCTION(SDL_HasKeyboard), asCALL_CDECL);
 	engine->RegisterGlobalFunction(_O("uint get_key_code(const string&in name)"), asFUNCTION(GetKeyCode), asCALL_CDECL);
 	engine->RegisterGlobalFunction(_O("string get_key_name(uint key)"), asFUNCTION(GetKeyName), asCALL_CDECL);

--- a/test/quick/get_characters.nvgt
+++ b/test/quick/get_characters.nvgt
@@ -1,3 +1,7 @@
+// NonVisual Gaming Toolkit (NVGT)
+// Copyright (C) 2022-2024 Sam Tupy
+// License: zlib (see license.md in the root of the NVGT distribution)
+
 void main() {
 	show_window("Test get_characters");
 	// It is necessary to start text input on android for get _characters to work.
@@ -14,6 +18,7 @@ void main() {
 	tts_voice tts;
 	string characters;
 
+	tts.speak_interrupt("Type any character on the keyboard, and I will speak that for you!");
 	while (!key_pressed(KEY_ESCAPE)) {
 		wait(5);
 		characters = get_characters();

--- a/test/quick/get_characters.nvgt
+++ b/test/quick/get_characters.nvgt
@@ -1,0 +1,25 @@
+void main() {
+	show_window("Test get_characters");
+	// It is necessary to start text input on android for get _characters to work.
+	// Because SDL shows on screen keyboard by default when you start input,
+	//you have to set a hint once that disables this behavior.
+	// Note: the hint should be set before calling start_text_input.
+	sdl_set_hint("SDL_ENABLE_SCREEN_KEYBOARD", "0");
+	start_text_input();
+	if (!text_input_active()) {
+		alert("Error", "Text input couldn't start");
+		exit();
+	}
+
+	tts_voice tts;
+	string characters;
+
+	while (!key_pressed(KEY_ESCAPE)) {
+		wait(5);
+		characters = get_characters();
+		if (characters.empty())
+			continue;
+
+		tts.speak_interrupt(characters);
+	}
+}

--- a/test/quick/get_key_name.nvgt
+++ b/test/quick/get_key_name.nvgt
@@ -1,3 +1,7 @@
+// NonVisual Gaming Toolkit (NVGT)
+// Copyright (C) 2022-2024 Sam Tupy
+// License: zlib (see license.md in the root of the NVGT distribution)
+
 tts_voice tts;
 
 void main() {

--- a/test/quick/has_keyboard.nvgt
+++ b/test/quick/has_keyboard.nvgt
@@ -1,3 +1,7 @@
+// NonVisual Gaming Toolkit (NVGT)
+// Copyright (C) 2022-2024 Sam Tupy
+// License: zlib (see license.md in the root of the NVGT distribution)
+
 void main() {
 	show_window("Test");
 	alert("Alert", (has_keyboard()) ? "Keyboard atached" : "Keyboard not atached");


### PR DESCRIPTION
This PR tries to address get_characters not working on Android by registering the function that start/stop text input. Because SDL 3 allows to disable the behavior of showing the on screen keyboard, we will do by testing a hint. See the test case for that.

This PR registers 3 functons:
1. `bool start_text_input();`
2. `bool stop_text_input()`
3. `bool text_input_active();`.
