### PR TITLE
Code maintenance

### DIFF
--- a/release/include/form.nvgt
+++ b/release/include/form.nvgt
@@ -1973,7 +1973,7 @@ class audio_form {
 		}
 		return true;
 	}
-	bool set_input_read_only(int control_index, bool read_only) {
+	bool set_read_only(int control_index, bool read_only) {
 		form_error = 0;
 		if (!active) {
 			form_error = form_error_no_window;
@@ -1983,7 +1983,7 @@ class audio_form {
 			form_error = form_error_invalid_index;
 			return false;
 		}
-		if (c_form[control_index].type != ct_input) {
+		if (c_form[control_index].type != ct_input && c_form[control_index].type != ct_checkbox) {
 			form_error = form_error_invalid_control;
 			return false;
 		}

--- a/test/quick/KEYBOARD_AVAILABLE.nvgt
+++ b/test/quick/KEYBOARD_AVAILABLE.nvgt
@@ -4,5 +4,5 @@
 
 void main() {
 	show_window("Test");
-	alert("Alert", (has_keyboard()) ? "Keyboard atached" : "Keyboard not atached");
+	alert("Alert", (KEYBOARD_AVAILABLE) ? "Keyboard atached" : "Keyboard not atached");
 }

--- a/test/quick/get_characters.nvgt
+++ b/test/quick/get_characters.nvgt
@@ -7,6 +7,8 @@ void main() {
 	// It is necessary to start text input on android for get _characters to work.
 	// Because SDL shows on screen keyboard by default when you start input,
 	//you have to set a hint once that disables this behavior.
+	//  We do this so the touch.nvgt and onscreen keyboards don't have a conflict.
+	// Useful for the times when the user has disabled the screen reader and is using the tts_voice for reader output.
 	// Note: the hint should be set before calling start_text_input.
 	sdl_set_hint("SDL_ENABLE_SCREEN_KEYBOARD", "0");
 	start_text_input();


### PR DESCRIPTION
This PR fixes some of the issues introduced in recent PRs.
1. Makes the set_read_only method in audio_form class to account for checkboxes.
2. Fixes the KEYBOARD_AVAILABLE test case.
3. Adds an aditional comments in the get_characters in test/quick to explain why we are hiding the keyboard.
