### PR TITLE
Fixed touch.nvgt

### DIFF
--- a/release/include/touch.nvgt
+++ b/release/include/touch.nvgt
@@ -146,7 +146,7 @@ class touch_gesture_manager {
 		}
 			else {
 			if(interfaces.length()<=0) return false;
-			this.interfaces.insert_last(interfaces);
+			this.interfaces.extend(interfaces);
 		}
 		return true;
 	}


### PR DESCRIPTION
This PR fixes a bug in touch.nvgt that caused compile error. In line 149, the old overload was being used. It has now been replaced with extend method.