### PR TITLE
Added function to decode HTML entities

### DIFF
--- a/src/entities.cpp
+++ b/src/entities.cpp
@@ -1,0 +1,389 @@
+/*        Copyright 2012, 2016 Christoph Gärtner
+        Distributed under the Boost Software License, Version 1.0
+*/
+
+#include "entities.h"
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#pragma warning(disable: 4706)
+
+#define UNICODE_MAX 0x10FFFFul
+
+static const char *const NAMED_ENTITIES[][2] = {
+        { "AElig;", "Æ" },
+        { "Aacute;", "Á" },
+        { "Acirc;", "Â" },
+        { "Agrave;", "À" },
+        { "Alpha;", "Α" },
+        { "Aring;", "Å" },
+        { "Atilde;", "Ã" },
+        { "Auml;", "Ä" },
+        { "Beta;", "Β" },
+        { "Ccedil;", "Ç" },
+        { "Chi;", "Χ" },
+        { "Dagger;", "‡" },
+        { "Delta;", "Δ" },
+        { "ETH;", "Ð" },
+        { "Eacute;", "É" },
+        { "Ecirc;", "Ê" },
+        { "Egrave;", "È" },
+        { "Epsilon;", "Ε" },
+        { "Eta;", "Η" },
+        { "Euml;", "Ë" },
+        { "Gamma;", "Γ" },
+        { "Iacute;", "Í" },
+        { "Icirc;", "Î" },
+        { "Igrave;", "Ì" },
+        { "Iota;", "Ι" },
+        { "Iuml;", "Ï" },
+        { "Kappa;", "Κ" },
+        { "Lambda;", "Λ" },
+        { "Mu;", "Μ" },
+        { "Ntilde;", "Ñ" },
+        { "Nu;", "Ν" },
+        { "OElig;", "Œ" },
+        { "Oacute;", "Ó" },
+        { "Ocirc;", "Ô" },
+        { "Ograve;", "Ò" },
+        { "Omega;", "Ω" },
+        { "Omicron;", "Ο" },
+        { "Oslash;", "Ø" },
+        { "Otilde;", "Õ" },
+        { "Ouml;", "Ö" },
+        { "Phi;", "Φ" },
+        { "Pi;", "Π" },
+        { "Prime;", "″" },
+        { "Psi;", "Ψ" },
+        { "Rho;", "Ρ" },
+        { "Scaron;", "Š" },
+        { "Sigma;", "Σ" },
+        { "THORN;", "Þ" },
+        { "Tau;", "Τ" },
+        { "Theta;", "Θ" },
+        { "Uacute;", "Ú" },
+        { "Ucirc;", "Û" },
+        { "Ugrave;", "Ù" },
+        { "Upsilon;", "Υ" },
+        { "Uuml;", "Ü" },
+        { "Xi;", "Ξ" },
+        { "Yacute;", "Ý" },
+        { "Yuml;", "Ÿ" },
+        { "Zeta;", "Ζ" },
+        { "aacute;", "á" },
+        { "acirc;", "â" },
+        { "acute;", "´" },
+        { "aelig;", "æ" },
+        { "agrave;", "à" },
+        { "alefsym;", "ℵ" },
+        { "alpha;", "α" },
+        { "amp;", "&" },
+        { "and;", "∧" },
+        { "ang;", "∠" },
+        { "apos;", "'" },
+        { "aring;", "å" },
+        { "asymp;", "≈" },
+        { "atilde;", "ã" },
+        { "auml;", "ä" },
+        { "bdquo;", "„" },
+        { "beta;", "β" },
+        { "brvbar;", "¦" },
+        { "bull;", "•" },
+        { "cap;", "∩" },
+        { "ccedil;", "ç" },
+        { "cedil;", "¸" },
+        { "cent;", "¢" },
+        { "chi;", "χ" },
+        { "circ;", "ˆ" },
+        { "clubs;", "♣" },
+        { "cong;", "≅" },
+        { "copy;", "©" },
+        { "crarr;", "↵" },
+        { "cup;", "∪" },
+        { "curren;", "¤" },
+        { "dArr;", "⇓" },
+        { "dagger;", "†" },
+        { "darr;", "↓" },
+        { "deg;", "°" },
+        { "delta;", "δ" },
+        { "diams;", "♦" },
+        { "divide;", "÷" },
+        { "eacute;", "é" },
+        { "ecirc;", "ê" },
+        { "egrave;", "è" },
+        { "empty;", "∅" },
+        { "emsp;", "\xE2\x80\x83" },
+        { "ensp;", "\xE2\x80\x82" },
+        { "epsilon;", "ε" },
+        { "equiv;", "≡" },
+        { "eta;", "η" },
+        { "eth;", "ð" },
+        { "euml;", "ë" },
+        { "euro;", "€" },
+        { "exist;", "∃" },
+        { "fnof;", "ƒ" },
+        { "forall;", "∀" },
+        { "frac12;", "½" },
+        { "frac14;", "¼" },
+        { "frac34;", "¾" },
+        { "frasl;", "⁄" },
+        { "gamma;", "γ" },
+        { "ge;", "≥" },
+        { "gt;", ">" },
+        { "hArr;", "⇔" },
+        { "harr;", "↔" },
+        { "hearts;", "♥" },
+        { "hellip;", "…" },
+        { "iacute;", "í" },
+        { "icirc;", "î" },
+        { "iexcl;", "¡" },
+        { "igrave;", "ì" },
+        { "image;", "ℑ" },
+        { "infin;", "∞" },
+        { "int;", "∫" },
+        { "iota;", "ι" },
+        { "iquest;", "¿" },
+        { "isin;", "∈" },
+        { "iuml;", "ï" },
+        { "kappa;", "κ" },
+        { "lArr;", "⇐" },
+        { "lambda;", "λ" },
+        { "lang;", "〈" },
+        { "laquo;", "«" },
+        { "larr;", "←" },
+        { "lceil;", "⌈" },
+        { "ldquo;", "“" },
+        { "le;", "≤" },
+        { "lfloor;", "⌊" },
+        { "lowast;", "∗" },
+        { "loz;", "◊" },
+        { "lrm;", "\xE2\x80\x8E" },
+        { "lsaquo;", "‹" },
+        { "lsquo;", "‘" },
+        { "lt;", "<" },
+        { "macr;", "¯" },
+        { "mdash;", "—" },
+        { "micro;", "µ" },
+        { "middot;", "·" },
+        { "minus;", "−" },
+        { "mu;", "μ" },
+        { "nabla;", "∇" },
+        { "nbsp;", "\xC2\xA0" },
+        { "ndash;", "–" },
+        { "ne;", "≠" },
+        { "ni;", "∋" },
+        { "not;", "¬" },
+        { "notin;", "∉" },
+        { "nsub;", "⊄" },
+        { "ntilde;", "ñ" },
+        { "nu;", "ν" },
+        { "oacute;", "ó" },
+        { "ocirc;", "ô" },
+        { "oelig;", "œ" },
+        { "ograve;", "ò" },
+        { "oline;", "‾" },
+        { "omega;", "ω" },
+        { "omicron;", "ο" },
+        { "oplus;", "⊕" },
+        { "or;", "∨" },
+        { "ordf;", "ª" },
+        { "ordm;", "º" },
+        { "oslash;", "ø" },
+        { "otilde;", "õ" },
+        { "otimes;", "⊗" },
+        { "ouml;", "ö" },
+        { "para;", "¶" },
+        { "part;", "∂" },
+        { "permil;", "‰" },
+        { "perp;", "⊥" },
+        { "phi;", "φ" },
+        { "pi;", "π" },
+        { "piv;", "ϖ" },
+        { "plusmn;", "±" },
+        { "pound;", "£" },
+        { "prime;", "′" },
+        { "prod;", "∏" },
+        { "prop;", "∝" },
+        { "psi;", "ψ" },
+        { "quot;", "\"" },
+        { "rArr;", "⇒" },
+        { "radic;", "√" },
+        { "rang;", "〉" },
+        { "raquo;", "»" },
+        { "rarr;", "→" },
+        { "rceil;", "⌉" },
+        { "rdquo;", "”" },
+        { "real;", "ℜ" },
+        { "reg;", "®" },
+        { "rfloor;", "⌋" },
+        { "rho;", "ρ" },
+        { "rlm;", "\xE2\x80\x8F" },
+        { "rsaquo;", "›" },
+        { "rsquo;", "’" },
+        { "sbquo;", "‚" },
+        { "scaron;", "š" },
+        { "sdot;", "⋅" },
+        { "sect;", "§" },
+        { "shy;", "\xC2\xAD" },
+        { "sigma;", "σ" },
+        { "sigmaf;", "ς" },
+        { "sim;", "∼" },
+        { "spades;", "♠" },
+        { "sub;", "⊂" },
+        { "sube;", "⊆" },
+        { "sum;", "∑" },
+        { "sup1;", "¹" },
+        { "sup2;", "²" },
+        { "sup3;", "³" },
+        { "sup;", "⊃" },
+        { "supe;", "⊇" },
+        { "szlig;", "ß" },
+        { "tau;", "τ" },
+        { "there4;", "∴" },
+        { "theta;", "θ" },
+        { "thetasym;", "ϑ" },
+        { "thinsp;", "\xE2\x80\x89" },
+        { "thorn;", "þ" },
+        { "tilde;", "˜" },
+        { "times;", "×" },
+        { "trade;", "™" },
+        { "uArr;", "⇑" },
+        { "uacute;", "ú" },
+        { "uarr;", "↑" },
+        { "ucirc;", "û" },
+        { "ugrave;", "ù" },
+        { "uml;", "¨" },
+        { "upsih;", "ϒ" },
+        { "upsilon;", "υ" },
+        { "uuml;", "ü" },
+        { "weierp;", "℘" },
+        { "xi;", "ξ" },
+        { "yacute;", "ý" },
+        { "yen;", "¥" },
+        { "yuml;", "ÿ" },
+        { "zeta;", "ζ" },
+        { "zwj;", "\xE2\x80\x8D" },
+        { "zwnj;", "\xE2\x80\x8C" }
+};
+
+static int cmp(const void *key, const void *value)
+{
+        return strncmp((const char *)key, *(const char *const *)value,
+                strlen(*(const char *const *)value));
+}
+
+static const char *get_named_entity(const char *name)
+{
+        const char *const *entity = (const char *const *)bsearch(name,
+                NAMED_ENTITIES, sizeof NAMED_ENTITIES / sizeof *NAMED_ENTITIES,
+                sizeof *NAMED_ENTITIES, cmp);
+
+        return entity ? entity[1] : NULL;
+}
+
+static size_t putc_utf8(unsigned long cp, char *buffer)
+{
+        unsigned char *bytes = (unsigned char *)buffer;
+
+        if(cp <= 0x007Ful)
+        {
+                bytes[0] = (unsigned char)cp;
+                return 1;
+        }
+
+        if(cp <= 0x07FFul)
+        {
+                bytes[1] = (unsigned char)((2 << 6) | (cp & 0x3F));
+                bytes[0] = (unsigned char)((6 << 5) | (cp >> 6));
+                return 2;
+        }
+
+        if(cp <= 0xFFFFul)
+        {
+                bytes[2] = (unsigned char)(( 2 << 6) | ( cp       & 0x3F));
+                bytes[1] = (unsigned char)(( 2 << 6) | ((cp >> 6) & 0x3F));
+                bytes[0] = (unsigned char)((14 << 4) |  (cp >> 12));
+                return 3;
+        }
+
+        if(cp <= 0x10FFFFul)
+        {
+                bytes[3] = (unsigned char)(( 2 << 6) | ( cp        & 0x3F));
+                bytes[2] = (unsigned char)(( 2 << 6) | ((cp >>  6) & 0x3F));
+                bytes[1] = (unsigned char)(( 2 << 6) | ((cp >> 12) & 0x3F));
+                bytes[0] = (unsigned char)((30 << 3) |  (cp >> 18));
+                return 4;
+        }
+
+        return 0;
+}
+
+static bool parse_entity(
+        const char *current, char **to, const char **from)
+{
+        const char *end = strchr(current, ';');
+        if(!end) return 0;
+
+        if(current[1] == '#')
+        {
+                char *tail = NULL;
+                int errno_save = errno;
+                bool hex = current[2] == 'x' || current[2] == 'X';
+
+                errno = 0;
+                unsigned long cp = strtoul(
+                        current + (hex ? 3 : 2), &tail, hex ? 16 : 10);
+
+                bool fail = errno || tail != end || cp > UNICODE_MAX;
+                errno = errno_save;
+                if(fail) return 0;
+
+                *to += putc_utf8(cp, *to);
+                *from = end + 1;
+
+                return 1;
+        }
+        else
+        {
+                const char *entity = get_named_entity(&current[1]);
+                if(!entity) return 0;
+
+                size_t len = strlen(entity);
+                memcpy(*to, entity, len);
+
+                *to += len;
+                *from = end + 1;
+
+                return 1;
+        }
+}
+
+size_t decode_html_entities_utf8(char *dest, const char *src)
+{
+        if(!src) src = dest;
+
+        char *to = dest;
+        const char *from = src;
+
+        for(const char *current; (current = strchr(from, '&'));)
+        {
+                memmove(to, from, (size_t)(current - from));
+                to += current - from;
+
+                if(parse_entity(current, &to, &from))
+                        continue;
+
+                from = current;
+                *to++ = *from++;
+        }
+
+        size_t remaining = strlen(from);
+
+        memmove(to, from, remaining);
+        to += remaining;
+        *to = 0;
+
+        return (size_t)(to - dest);
+}

--- a/src/entities.h
+++ b/src/entities.h
@@ -1,0 +1,20 @@
+/*        Copyright 2012 Christoph Gärtner
+        Distributed under the Boost Software License, Version 1.0
+*/
+
+#ifndef DECODE_HTML_ENTITIES_UTF8_
+#define DECODE_HTML_ENTITIES_UTF8_
+
+#include <stddef.h>
+
+extern size_t decode_html_entities_utf8(char *dest, const char *src);
+/*        Takes input from <src> and decodes into <dest>, which should be a buffer
+        large enough to hold <strlen(src) + 1> characters.
+
+        If <src> is <NULL>, input will be taken from <dest>, decoding
+        the entities in-place.
+
+        The function returns the length of the decoded string.
+*/
+
+#endif

--- a/src/internet.cpp
+++ b/src/internet.cpp
@@ -39,6 +39,7 @@
 #include <scriptdictionary.h>
 #include "datastreams.h"
 #include "internet.h"
+#include "entities.h"
 #include "nvgt.h"
 #include "nvgt_angelscript.h"
 #include "pocostuff.h" // angelscript_refcounted
@@ -47,6 +48,12 @@
 using namespace std;
 using namespace Poco;
 using namespace Poco::Net;
+
+string html_entities_decode(const string& input) {
+	vector<char> buffer(input.size() + 1, '\0');
+	decode_html_entities_utf8(buffer.data(), input.c_str());
+	return string(buffer.data());
+}
 
 string url_encode(const string& url, const string& reserved) {
 	string result;
@@ -799,6 +806,7 @@ void RegisterInternet(asIScriptEngine* engine) {
 	engine->RegisterEnumValue("socket_select_mode", "SOCKET_SELECT_READ", Socket::SELECT_READ);
 	engine->RegisterEnumValue("socket_select_mode", "SOCKET_SELECT_WRITE", Socket::SELECT_WRITE);
 	engine->RegisterEnumValue("socket_select_mode", "SOCKET_SELECT_ERROR", Socket::SELECT_ERROR);
+	engine->RegisterGlobalFunction(_O("string html_entities_decode(const string&in input)"), asFUNCTION(html_entities_decode), asCALL_CDECL);
 	engine->RegisterGlobalFunction(_O("string url_encode(const string&in url, const string&in reserved = \"\")"), asFUNCTION(url_encode), asCALL_CDECL);
 	engine->RegisterGlobalFunction(_O("string url_decode(const string&in url, bool plus_as_space = true)"), asFUNCTION(url_decode), asCALL_CDECL);
 	RegisterNameValueCollection<NameValueCollection>(engine, "name_value_collection");

--- a/src/internet.h
+++ b/src/internet.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <string>
 #include <angelscript.h>
 
+std::string html_entities_decode(const std::string& input);
 void RegisterInternet(asIScriptEngine* engine);

--- a/test/quick/html_entities_decode.nvgt
+++ b/test/quick/html_entities_decode.nvgt
@@ -1,0 +1,8 @@
+// NonVisual Gaming Toolkit (NVGT)
+// Copyright (C) 2022-2024 Sam Tupy
+// License: zlib (see license.md in the root of the NVGT distribution)
+
+void main() {
+	string result = html_entities_decode("ol&aacute;, como voc&ecirc; est&aacute;?");
+	alert(result, "");
+}


### PR DESCRIPTION
The library used to convert the entities was created by Christoph Gärtner, and is distributed under the Boost Software License, Version 1.0, so it can be used on NVGT with no problems.
An example of how to use the new function has also been added.