### PR TITLE
Generate a latest development release every time code is merged into main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: release
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
       - "*"
 
@@ -200,6 +202,33 @@ jobs:
       with:
         name: linux_package
         path: 'nvgt_${{env.nvgt_version}}.tar.gz'
+
+  publish_latest:
+    runs-on: ubuntu-latest
+    needs: ["windows_package", "mac_package", "linux_package"]
+    if: github.ref == 'refs/heads/main' && github.event.repository.fork == false
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: '*_package'
+    - uses: actions/download-artifact@v4
+      with:
+        name: android_release
+    - name: set_version
+      run: python3 build/ci_set_version.py
+    - name: preprocess
+      run: |
+        mkdir android_package
+        mv android_release/nvgt.apk android_package/nvgt_android_$nvgt_version.apk
+    - name: publish
+      uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: true
+        title: "Latest Development Version"
+        automatic_release_tag: "latest"
+        files: '*_package/nvgt_${{env.nvgt_version}}.*'
 
   publish_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR introduces a job similar to the publish_release job, but this makes or updates a latest tag, with the most recent code from main, packaged into the respective platform installers.
It creates a latest development version release that's always going to be up to date with main. Think a bleeding edge/nightly build