### PR TITLE
Fix bug when resetting active profiler

### DIFF
--- a/src/scriptstuff.cpp
+++ b/src/scriptstuff.cpp
@@ -134,16 +134,22 @@ void reset_profiler() {
 	profiler_ticks = std::chrono::high_resolution_clock::now();
 	profiler_start = std::chrono::high_resolution_clock::now();
 	profiler_last_func = NULL;
+	prepare_profiler();
+}
+void prepare_profiler()
+{
+	if (!is_profiling) return;
+	asIScriptContext* ctx = asGetActiveContext();
+	if (!ctx) return;
+	profiler_last_func = ctx->GetFunction();
+	profiler_cache[profiler_last_func] = profiler_start;
 }
 void start_profiling() {
-	asIScriptContext* ctx = asGetActiveContext();
 	if (is_profiling) return;
-	reset_profiler();
-	if (ctx) {
+	asIScriptContext* ctx = asGetActiveContext();
+	if (!ctx) return;
 		is_profiling = true;
-		profiler_last_func = ctx->GetFunction();
-		profiler_cache[profiler_last_func] = profiler_start;
-	}
+	reset_profiler();
 }
 void stop_profiling() {
 	asIScriptContext* ctx = asGetActiveContext();

--- a/src/scriptstuff.h
+++ b/src/scriptstuff.h
@@ -18,6 +18,7 @@
 bool script_compiled();
 void profiler_callback(asIScriptContext* ctx, void* obj);
 extern int g_GCMode;
+void prepare_profiler();
 void garbage_collect_action();
 extern asIScriptFunction* profiler_last_func;
 extern int profiler_current_line;


### PR DESCRIPTION
If reset_profiler was called while profiling was enabled, the callback would attempt to increase the elapsed time of a non-existent entry in the cache. This caused uninitialized values to be stored, leading to invalid results being returned from the profiler.

This fix ensures that resetting will reinitialize the profiler if it is still enabled.