### PR TITLE
Few suggested fixes to embedded pack workflows

### DIFF
--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -522,9 +522,6 @@ std::unordered_map<std::string, std::string> embedding_packs; // embed_filename:
 std::unordered_map<std::string, embedded_pack> embedded_packs; // embed_filename:embed_offset/size
 void embed_pack(const std::string& disc_filename, const std::string& embed_filename) {
 	if (embedding_packs.find(embed_filename) != embedding_packs.end()) return;
-	// Try opening the file to insure it exists and is readable, exception will be thrown if not.
-	Poco::FileInputStream tmp(disc_filename);
-	tmp.close();
 	embedding_packs[embed_filename] = disc_filename;
 }
 bool load_embedded_packs(Poco::BinaryReader& br) {

--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -553,7 +553,7 @@ bool find_embedded_pack(std::string& filename, uint64_t& file_offset, uint64_t& 
 	#ifndef NVGT_STUB
 	// If running from nvgt's compiler the packs are not actually embedded, translate the user input back to a valid filename.
 	if (filename == "*" && embedding_packs.size() > 0) filename = embedding_packs.begin()->second; // BGT compatibility
-	else filename = filename.substr(1);
+	else filename = embedding_packs[filename];
 	return true;
 	#else
 	const auto& it = filename == "*" ? embedded_packs.begin() : embedded_packs.find(filename.substr(1));


### PR DESCRIPTION
I noticed that a game would refuse to run from source if an embedded pack didn't exist, regardless of whether you would be using a pack file in that situation. So I removed the existence check from embed_pack. This makes it easier for a workflow where you would use raw assets to begin with and only build the pack file when you're ready to compile/distribute.

While looking through the code to do this, I also discovered that the find_embedded_packs function merely removed the * prefix when running from source, making an assumption that the disk filename would always be the same as the embedded filename. So I also fixed that to use the disk filename instead.
