### PR TITLE
Rough and early implementation of tone_synth

### DIFF
--- a/dep/_SConscript
+++ b/dep/_SConscript
@@ -6,7 +6,7 @@
 Import("env")
 #env.Append(CPPDEFINES = ["WDL_ALLOW_UNSIGNED_DEFAULT_CHAR"])
 
-sources = ["aes.c", "cmp.c", "entities.cpp", "ma_reverb_node.c", "micropather.cpp", "miniaudio.c", "miniaudio_libvorbis.c", "miniaudio_phonon.c", "miniaudio_wdl_resampler.cpp", "monocypher.c", "resample.cpp", "rng_get_bytes.c", "singleheader.cpp", "sonic.c", "tinyexpr.c", "uncompr.c"]
+sources = ["aes.c", "cmp.c", "entities.cpp", "ma_reverb_node.c", "micropather.cpp", "miniaudio.c", "miniaudio_libvorbis.c", "miniaudio_phonon.c", "miniaudio_wdl_resampler.cpp", "monocypher.c", "resample.cpp", "rng_get_bytes.c", "singleheader.cpp", "sonic.c", "tinyexpr.c", "uncompr.c", "tonar.c"]
 if env["PLATFORM"] == "win32":
 	sources += ["blastspeak.c", "InputBox.cpp", "vs_version.cpp"]
 env.StaticLibrary("#build/lib/deps", sources, CPPDEFINES = ["_LIB"])

--- a/dep/tonar.c
+++ b/dep/tonar.c
@@ -1,0 +1,398 @@
+#include "tonar.h"
+
+int el_tonar_reset(el_tonar* gen)
+{
+if(!gen) return 0;
+elz_tonar_cleanup(gen);
+gen->data=NULL;
+gen->cursor=0;
+gen->length=0;
+gen->size=0;
+gen->waveform=waveform_sine;
+gen->volume=0;
+gen->pan=0;
+gen->fade_start=8;
+gen->fade_end=12;
+gen->sample_rate=44100;
+gen->channels=2;
+gen->peak=0;
+gen->begin=elz_tonar_begin;
+gen->end=elz_tonar_end;
+return 1;
+}
+int el_tonar_set_waveform(el_tonar* gen, int type)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(type<0) return 0;
+if(type>=waveform_max) return 0;
+gen->waveform=type;
+return 1;
+}
+int el_tonar_set_volume(el_tonar* gen, double db)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(db>0) return 0;
+if(db<-100) return 0;
+gen->volume=db;
+return 1;
+}
+int el_tonar_set_pan(el_tonar* gen, double pan)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(pan<-100) return 0;
+if(pan>100) return 0;
+gen->pan=pan;
+return 1;
+}
+int el_tonar_set_edge_fades(el_tonar* gen, int start, int end)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(start<0) return 0;
+if(end<0) return 0;
+gen->fade_start=start;
+gen->fade_end=end;
+return 1;
+}
+int el_tonar_freq(el_tonar* gen, double freq, int ms)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(freq<20) return 0;
+if(freq>20000) return 0;
+if(ms<=0) return 0;
+int frames=elz_tonar_ms_to_frames(gen, ms);
+if(frames<=0) return 0;
+int samples=frames*gen->channels;
+if(!elz_tonar_manage_buffer(gen, samples)) return 0;
+double amplitude=elz_tonar_db_to_amp(gen->volume);
+int sample_rate=gen->sample_rate;
+int fade_start=elz_tonar_calculate_fade_start(gen, ms);
+int fade_end=elz_tonar_calculate_fade_end(gen, ms);
+int fade_in_frames=elz_tonar_ms_to_frames(gen, fade_start);
+int fade_out_frames=elz_tonar_ms_to_frames(gen, fade_end);
+for(int x=0; x<frames; x++)
+{
+double sample=elz_tonar_generate_waveform(gen->waveform, x, freq, sample_rate, amplitude);
+sample=elz_tonar_apply_fade_in(x, fade_in_frames, sample);
+sample=elz_tonar_apply_fade_out(x, frames, fade_out_frames, sample);
+int offset=elz_tonar_get_offset(gen, x);
+elz_tonar_add_sample(gen, offset, sample);
+}
+return elz_tonar_adjust_length(gen, samples);
+}
+int el_tonar_rest(el_tonar* gen, int ms)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(ms<=0) return 0;
+int frames=elz_tonar_ms_to_frames(gen, ms);
+if(frames<=0) return 0;
+int samples=frames*gen->channels;
+if(!elz_tonar_manage_buffer(gen, samples)) return 0;
+gen->cursor+=samples;
+if(gen->cursor>gen->length) gen->length=gen->cursor;
+return 1;
+}
+int el_tonar_output_buffer_size(el_tonar* gen)
+{
+if(elz_tonar_is_silent(gen)) return 0;
+int samples=gen->length;
+int bytes_per_sample=2;
+return samples*bytes_per_sample;
+}
+int el_tonar_output_buffer(el_tonar* gen, char* buffer, int size)
+{
+int needed=el_tonar_output_buffer_size(gen);
+if(needed<=0) return 0;
+if(size<needed) return 0;
+for(int x=0; x<gen->length; x++)
+{
+double new_sample=elz_tonar_normalise_sample(gen, x);
+short output_sample=elz_tonar_float_to_sample(new_sample);
+memcpy(buffer, &output_sample, sizeof(output_sample));
+buffer+=sizeof(output_sample);
+}
+return 1;
+}
+int el_tonar_output_file(el_tonar* gen, char* fn)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(elz_tonar_is_silent(gen)) return 1;
+int outsize=el_tonar_output_buffer_size(gen);
+if(outsize<=0) return 0;
+char* output=malloc(outsize+44);
+if(!output) return 0;
+if(!elz_tonar_output_wave_header(gen, output, 44, outsize))
+{
+free(output);
+return 0;
+}
+char* data=output+44;
+if(!el_tonar_output_buffer(gen, data, outsize))
+{
+free(output);
+return 0;
+}
+FILE* f=fopen(fn, "wb");
+if(!f)
+{
+free(output);
+return 0;
+}
+fwrite(output, sizeof(char), outsize+44, f);
+fclose(f);
+free(output);
+return 1;
+}
+int elz_tonar_cleanup(el_tonar* gen)
+{
+if(!elz_tonar_is_init(gen)) return 1;
+if(gen->data) free(gen->data);
+return 1;
+}
+int elz_tonar_is_init(el_tonar* gen)
+{
+if(!gen) return 0;
+if(gen->begin!=elz_tonar_begin) return 0;
+if(gen->end!=elz_tonar_end) return 0;
+return 1;
+}
+int elz_tonar_is_empty(el_tonar* gen)
+{
+if(!elz_tonar_is_init(gen)) return 1;
+if(!gen->data) return 1;
+if(gen->size<=0) return 1;
+return 0;
+}
+int elz_tonar_is_silent(el_tonar* gen)
+{
+if(elz_tonar_is_empty(gen)) return 1;
+if(gen->peak<=0) return 1;
+return 0;
+}
+int elz_tonar_ms_to_frames(el_tonar* gen, int ms)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+double rate_ms=(double) gen->sample_rate/1000;
+rate_ms*=ms;
+return rate_ms;
+}
+int elz_tonar_manage_buffer(el_tonar* gen, int samples)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+samples+=gen->cursor;
+if(samples<gen->size) return 1;
+samples*=2;
+double* data=realloc(gen->data, samples*sizeof(double));
+if(!data) return 0;
+memset(data+gen->size, 0, samples-gen->size);
+gen->data=data;
+gen->size=samples;
+return 1;
+}
+double elz_tonar_generate_waveform(int type, int frame, double freq, int sample_rate, double amplitude)
+{
+if(type==waveform_sine) return elz_tonar_generate_sine(frame, freq, sample_rate, amplitude);
+if(type==waveform_triangle) return elz_tonar_generate_triangle_v2(frame, freq, sample_rate, amplitude);
+if(type==waveform_square) return elz_tonar_generate_square_v2(frame, freq, sample_rate, amplitude);
+if(type==waveform_saw) return elz_tonar_generate_saw_v2(frame, freq, sample_rate, amplitude);
+return 0;
+}
+double elz_tonar_generate_sine(int frame, double freq, int sample_rate, double amplitude)
+{
+double t=(double) frame/sample_rate;
+double value=amplitude*sin(2.0*M_PI*freq*t);
+return value;
+}
+double elz_tonar_generate_triangle(int frame, double freq, int sample_rate, double amplitude)
+{
+double t=(double) frame/sample_rate;
+double value=(2.0*amplitude/M_PI)*asin(sin(2.0*M_PI*freq*t));
+return value;
+}
+double elz_tonar_generate_triangle_v2(int frame, double freq, int sample_rate, double amplitude)
+{
+double t=(double) frame/sample_rate;
+double theta=2.0*M_PI*freq*t;
+double value=amplitude-(2.0*amplitude/M_PI)*fabs(fmod(theta+M_PI/2.0, 2.0*M_PI)-M_PI);
+return value;
+}
+double elz_tonar_generate_square(int frame, double freq, int sample_rate, double amplitude)
+{
+double t=(double) frame/sample_rate;
+double value=amplitude*(sin(2.0*M_PI*freq*t)>=0? 1.0: -1.0);
+return value;
+}
+double elz_tonar_generate_square_v2(int frame, double freq, int sample_rate, double amplitude)
+{
+double t=(double) frame/sample_rate;
+double dt=freq/sample_rate;
+double phase=fmod(freq*t, 1.0);
+double value=amplitude*(phase<0.5? 1.0: -1.0);
+value+=amplitude*elz_tonar_poly_blep(phase, dt);
+value-=amplitude*elz_tonar_poly_blep(fmod(phase+0.5, 1.0), dt);
+return value;
+}
+double elz_tonar_generate_saw(int frame, double freq, int sample_rate, double amplitude)
+{
+double t=(double) frame/sample_rate;
+double value=amplitude*(2.0*(t*freq-floor(0.5+t*freq)));
+return value;
+}
+double elz_tonar_generate_saw_v2(int frame, double freq, int sample_rate, double amplitude)
+{
+double t=(double) frame/sample_rate;
+double dt=freq/sample_rate;
+double phase=fmod(freq*t, 1.0);
+double value=amplitude*(2.0*phase-1.0);
+value-=amplitude*elz_tonar_poly_blep(phase, dt);
+return value;
+}
+double elz_tonar_normalise_sample(el_tonar* gen, int sample)
+{
+if(elz_tonar_is_silent(gen)) return 0;
+double peak=gen->peak;
+double value=gen->data[sample];
+if(peak<1.0) return value;
+double factor=1.0/peak;
+value*=factor;
+return value;
+}
+short elz_tonar_float_to_sample(double sample)
+{
+int min=-32768;
+int max=32767;
+int value=(int) (sample*max);
+if(value<min) value=min;
+if(value>max) value=max;
+return value;
+}
+int elz_tonar_output_wave_header(el_tonar* gen, char* buffer, int buffer_size, int data_size)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+if(buffer_size<44) return 0;
+int fsize=data_size+36;
+int csize=16;
+short format=1;
+short channels=gen->channels;
+int sample_rate=gen->sample_rate;
+short bits_per_sample=16;
+short bytes_per_block=channels*bits_per_sample/8;
+int bytes_per_sec=sample_rate*bytes_per_block;
+memcpy(buffer, "RIFF", 4);
+buffer+=4;
+memcpy(buffer, &fsize, sizeof(fsize));
+buffer+=sizeof(fsize);
+memcpy(buffer, "WAVEfmt ", 8);
+buffer+=8;
+memcpy(buffer, &csize, sizeof(csize));
+buffer+=sizeof(csize);
+memcpy(buffer, &format, sizeof(format));
+buffer+=sizeof(format);
+memcpy(buffer, &channels, sizeof(channels));
+buffer+=sizeof(channels);
+memcpy(buffer, &sample_rate, sizeof(sample_rate));
+buffer+=sizeof(sample_rate);
+memcpy(buffer, &bytes_per_sec, sizeof(bytes_per_sec));
+buffer+=sizeof(bytes_per_sec);
+memcpy(buffer, &bytes_per_block, sizeof(bytes_per_block));
+buffer+=sizeof(bytes_per_block);
+memcpy(buffer, &bits_per_sample, sizeof(bits_per_sample));
+buffer+=sizeof(bits_per_sample);
+memcpy(buffer, "data", 4);
+buffer+=4;
+memcpy(buffer, &data_size, sizeof(data_size));
+return 1;
+}
+int elz_tonar_get_offset(el_tonar* gen, int frame)
+{
+if(!elz_tonar_is_init(gen)) return -1;
+int offset=gen->cursor;
+offset+=frame*gen->channels;;
+if(offset>=gen->size) return -1;
+return offset;
+}
+void elz_tonar_add_sample(el_tonar* gen, int frame, double value)
+{
+if(!elz_tonar_is_init(gen)) return;
+if(gen->channels<1) return;
+if(gen->channels>2) return;
+if(gen->channels==1)
+{
+gen->data[frame]+=value;
+return;
+}
+double angle=(gen->pan+100)*M_PI_4/100;
+double left=value*cos(angle);
+double right=value*sin(angle);
+for(int x=0; x<gen->channels; x++)
+{
+int real_offset=frame+x;
+if(real_offset>=gen->size) return;
+if(x%2==0) gen->data[real_offset]+=left;
+if(x%2!=0) gen->data[real_offset]+=right;
+double peak=fabs(gen->data[real_offset]);
+if(peak>gen->peak) gen->peak=peak;
+}
+}
+double elz_tonar_db_to_amp(double db)
+{
+double amp=pow(10.0, db/20.0);
+return amp;
+}
+int elz_tonar_calculate_fade_start(el_tonar* gen, int ms)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+int start=gen->fade_start;
+int end=gen->fade_end;
+if(start<=0) return 0;
+int total=start+end;
+if(ms>total) return start;
+double ratio=(double) start/total;
+double result=ratio*ms;
+return result;
+}
+int elz_tonar_calculate_fade_end(el_tonar* gen, int ms)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+int start=gen->fade_start;
+int end=gen->fade_end;
+if(end<=0) return 0;
+int total=start+end;
+if(ms>total) return end;
+double ratio=(double) end/total;
+double result=ratio*ms;
+return result;
+}
+double elz_tonar_apply_fade_in(int frame, int fade_in_frames, double sample)
+{
+if(frame>=fade_in_frames) return sample;
+double fade_factor=(double) frame/fade_in_frames;
+return sample*fade_factor;
+}
+double elz_tonar_apply_fade_out(int frame, int total_frames, int fade_out_frames, double sample)
+{
+int fade_out_start_frame=total_frames-fade_out_frames;
+if(frame<fade_out_start_frame) return sample;
+double fade_factor=(double) (total_frames-frame)/fade_out_frames;
+return sample*fade_factor;
+}
+int elz_tonar_adjust_length(el_tonar* gen, int samples)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+int length=gen->cursor;
+if(length>gen->length) gen->length=length;
+return 1;
+}
+double elz_tonar_poly_blep(double t, double dt)
+{
+if(t<dt)
+{
+t/=dt;
+return t+t-t*t-1.0;
+}
+if(t>1.0-dt)
+{
+t=(t-1.0)/dt;
+return t*t+t+t+1.0;
+}
+return 0.0;
+}

--- a/dep/tonar.h
+++ b/dep/tonar.h
@@ -1,0 +1,89 @@
+#ifndef el_tonar_h
+#define el_tonar_h
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#define elz_tonar_begin 0xACC737A3
+#define elz_tonar_end 0xDC76AAED
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#ifndef M_PI_4
+#define M_PI_4 0.78539816339744830962
+#endif
+
+typedef enum
+{
+waveform_sine=0,
+waveform_triangle,
+waveform_square,
+waveform_saw,
+waveform_max,
+}
+el_tonar_waveform;
+
+typedef struct elz_tonar el_tonar;
+
+int el_tonar_reset(el_tonar* gen);
+int el_tonar_set_waveform(el_tonar* gen, int type);
+int el_tonar_set_volume(el_tonar* gen, double db);
+int el_tonar_set_pan(el_tonar* gen, double pan);
+int el_tonar_set_edge_fades(el_tonar* gen, int start, int end);
+int el_tonar_freq(el_tonar* gen, double freq, int ms);
+int el_tonar_rest(el_tonar* gen, int ms);
+int el_tonar_output_buffer_size(el_tonar* gen);
+int el_tonar_output_buffer(el_tonar* gen, char* buffer, int size);
+int el_tonar_output_file(el_tonar* gen, char* fn);
+
+struct elz_tonar
+{
+int begin;
+double* data;
+int cursor;
+int length;
+int size;
+int sample_rate;
+int channels;
+double peak;
+double pan;
+double volume;
+int fade_start;
+int fade_end;
+int waveform;
+int end;
+};
+
+int elz_tonar_cleanup(el_tonar* gen);
+int elz_tonar_is_init(el_tonar* gen);
+int elz_tonar_is_empty(el_tonar* gen);
+int elz_tonar_is_silent(el_tonar* gen);
+int elz_tonar_ms_to_frames(el_tonar* gen, int ms);
+int elz_tonar_manage_buffer(el_tonar* gen, int samples);
+double elz_tonar_generate_waveform(int type, int frame, double freq, int sample_rate, double amplitude);
+double elz_tonar_generate_sine(int frame, double freq, int sample_rate, double amplitude);
+double elz_tonar_generate_triangle(int frame, double freq, int sample_rate, double amplitude);
+double elz_tonar_generate_triangle_v2(int frame, double freq, int sample_rate, double amplitude);
+double elz_tonar_generate_square(int frame, double freq, int sample_rate, double amplitude);
+double elz_tonar_generate_square_v2(int frame, double freq, int sample_rate, double amplitude);
+double elz_tonar_generate_saw(int frame, double freq, int sample_rate, double amplitude);
+double elz_tonar_generate_saw_v2(int frame, double freq, int sample_rate, double amplitude);
+void elz_tonar_mix_sample(el_tonar* gen, int index, double value);
+double elz_tonar_normalise_sample(el_tonar* gen, int index);
+short elz_tonar_float_to_sample(double sample);
+int elz_tonar_output_wave_header(el_tonar* gen, char* buffer, int buffer_size, int data_size);
+int elz_tonar_get_offset(el_tonar* gen, int frame);
+void elz_tonar_add_sample(el_tonar* gen, int frame, double value);
+double elz_tonar_db_to_amp(double db);
+int elz_tonar_calculate_fade_start(el_tonar* gen, int ms);
+int elz_tonar_calculate_fade_end(el_tonar* gen, int ms);
+double elz_tonar_apply_fade_in(int frame, int fade_in_frames, double sample);
+double elz_tonar_apply_fade_out(int frame, int total_frames, int fade_out_frames, double sample);
+int elz_tonar_adjust_length(el_tonar* gen, int samples);
+double elz_tonar_poly_blep(double t, double dt);
+
+#endif

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -87,7 +87,7 @@ $(shell python "${LOCAL_PATH}/../build/version_sconscript.py")
 LOCAL_SRC_FILES_COMMON := \
     $(subst $(LOCAL_PATH)/,, \
     $(wildcard $(LOCAL_PATH)/../ASAddon/src/*.cpp)\
-    ../dep/aes.c ../dep/cmp.c ../dep/entities.cpp ../dep/ma_reverb_node.c ../dep/micropather.cpp ../dep/miniaudio.c ../dep/miniaudio_libvorbis.c ../dep/miniaudio_phonon.c ../dep/miniaudio_wdl_resampler.cpp ../dep/monocypher.c ../dep/resample.cpp ../dep/rng_get_bytes.c ../dep/singleheader.cpp ../dep/sonic.c ../dep/tinyexpr.c ../dep/uncompr.c\
+    ../dep/aes.c ../dep/cmp.c ../dep/entities.cpp ../dep/ma_reverb_node.c ../dep/micropather.cpp ../dep/miniaudio.c ../dep/miniaudio_libvorbis.c ../dep/miniaudio_phonon.c ../dep/miniaudio_wdl_resampler.cpp ../dep/monocypher.c ../dep/resample.cpp ../dep/rng_get_bytes.c ../dep/singleheader.cpp ../dep/sonic.c ../dep/tonar.c ../dep/tinyexpr.c ../dep/uncompr.c\
     $(wildcard $(LOCAL_PATH)/../src/*.cpp))
 LOCAL_C_INCLUDES_COMMON := $(LOCAL_PATH)/../droidev/include $(LOCAL_PATH)/../ASAddon/include $(LOCAL_PATH)/../dep
 LOCAL_CXXFLAGS_COMMON := -DPOCO_STATIC -DNVGT_BUILDING -DAS_USE_STLNAMES=1 -std=c++20 -fms-extensions -ffunction-sections -O2 -fpermissive -O2 -Wno-narrowing -Wno-int-to-pointer-cast -Wno-delete-incomplete -Wno-unused-result -Wno-deprecated-array-compare -Wno-implicit-const-int-float-conversion -Wno-deprecated-enum-enum-conversion -Wno-absolute-value

--- a/src/nvgt_angelscript.cpp
+++ b/src/nvgt_angelscript.cpp
@@ -65,6 +65,7 @@
 #include "system_fingerprint.h"
 #include "threading.h"
 #include "timestuff.h"
+#include "tonesynth.h"
 #include "tts.h"
 #include "version.h"
 #include "xplatform.h"
@@ -483,6 +484,9 @@ int ConfigureEngine(asIScriptEngine *engine) {
 	system_namespace("sound");
 	RegisterSoundsystem(engine);
 	system_namespace();
+	engine->EndConfigGroup();
+	engine->BeginConfigGroup("tonesynth");
+	RegisterScriptTonesynth(engine);
 	engine->EndConfigGroup();
 	engine->SetDefaultAccessMask(NVGT_SUBSYSTEM_UNCLASSIFIED);
 	engine->BeginConfigGroup("system_fingerprint");

--- a/src/tonesynth.cpp
+++ b/src/tonesynth.cpp
@@ -1,0 +1,111 @@
+/* tonesynth.cpp - code for the tone_synth object
+ * Written by Day Garwood, 30th May 2025
+ * This wraps a C implementation I made during September 2024.
+ * It's my first dive into low level synthesis and processing (yes, with the help of AI) so it's probably not ideal.
+ * It's certainly slower than I'd like, but it gets the feature started and working until a better implementation can be found.
+ * Todo: Since we're already using MiniAudio, discover how we might use ma_waveform for this, though not sure how much anti-aliasing it has.
+ * Todo: Musical concepts (notes, tempo, transposition etc), bends, and reverb still to be implemented.
+ *
+ * NVGT - NonVisual Gaming Toolkit
+ * Copyright (c) 2022-2024 Sam Tupy
+ * https://nvgt.gg
+ * This software is provided "as-is", without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+ * Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+ * 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "tonesynth.h"
+#include "sound.h"
+
+tone_synth::tone_synth() {
+	gen = new elz_tonar{};
+	el_tonar_reset(gen);
+}
+tone_synth::~tone_synth() {
+	if (!gen) return;
+	elz_tonar_cleanup(gen);
+	delete gen;
+}
+void tone_synth::AddRef() {
+	asAtomicInc(refCount);
+}
+void tone_synth::Release() {
+	if (asAtomicDec(refCount) < 1) {
+		delete this;
+	}
+}
+void tone_synth::set_waveform(int type) {
+	el_tonar_set_waveform(gen, type);
+}
+int tone_synth::get_waveform() {
+	return gen->waveform;
+}
+void tone_synth::set_volume(double db) {
+	el_tonar_set_volume(gen, db);
+}
+double tone_synth::get_volume() {
+	return gen->volume;
+}
+void tone_synth::set_pan(double pan) {
+	el_tonar_set_pan(gen, pan);
+}
+double tone_synth::get_pan() {
+	return gen->pan;
+}
+bool tone_synth::set_edge_fades(int start, int end) {
+	return el_tonar_set_edge_fades(gen, start, end)? true: false;
+}
+bool tone_synth::freq(double freq, int ms) {
+	return el_tonar_freq(gen, freq, ms)? true: false;
+}
+bool tone_synth::rest(int ms) {
+	return el_tonar_rest(gen, ms)? true: false;
+}
+sound* tone_synth::generate_sound() {
+	int size = el_tonar_output_buffer_size(gen);
+	if (size <= 0) return nullptr;
+	char* buffer = new char[size];
+	if (!buffer) return nullptr;
+	if (!el_tonar_output_buffer(gen, buffer, size)) {
+		delete[] buffer;
+		return nullptr;
+	}
+	// Todo: Review rest of this function. I have no idea how the sound system operates internally so am working off logical guesses here.
+	sound *s = new_global_sound();
+	if (!s) {
+		delete[] buffer;
+		return nullptr;
+	}
+	bool loaded = s->load_pcm(buffer, static_cast<unsigned int>(size), ma_format_s16, gen->sample_rate, gen->channels);
+	delete[] buffer; // I'm assuming this is now safely copied into the sound object.
+	if (!loaded) {
+		// Todo: Fix potential leak here. How would I free/release s?
+		return nullptr;
+	}
+	return s;
+}
+bool tone_synth::generate_file(const std::string& filename) {
+	return el_tonar_output_file(gen, const_cast<char*> (filename.c_str()))? true: false;
+}
+tone_synth *script_tone_synth_factory() {
+	return new tone_synth();
+}
+void RegisterScriptTonesynth(asIScriptEngine* engine) {
+	engine->RegisterObjectType("tone_synth", 0, asOBJ_REF);
+	engine->RegisterObjectBehaviour("tone_synth", asBEHAVE_FACTORY, "tone_synth@ f()", asFUNCTION(script_tone_synth_factory), asCALL_CDECL);
+	engine->RegisterObjectBehaviour("tone_synth", asBEHAVE_ADDREF, "void f()", asMETHOD(tone_synth, AddRef), asCALL_THISCALL);
+	engine->RegisterObjectBehaviour("tone_synth", asBEHAVE_RELEASE, "void f()", asMETHOD(tone_synth, Release), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "void set_waveform_type(int type) property", asMETHOD(tone_synth, set_waveform), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "int get_waveform_type() const property", asMETHOD(tone_synth, get_waveform), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "void set_volume(double value) property", asMETHOD(tone_synth, set_volume), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "double get_volume() const property", asMETHOD(tone_synth, get_volume), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "void set_pan(double value) property", asMETHOD(tone_synth, set_pan), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "double get_pan() const property", asMETHOD(tone_synth, get_pan), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool set_edge_fades(int start, int end)", asMETHOD(tone_synth, set_edge_fades), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool freq(double freq, int ms)", asMETHOD(tone_synth, freq), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool rest(int ms)", asMETHOD(tone_synth, rest), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "sound@ write_wave_sound()", asMETHOD(tone_synth, generate_sound), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool write_wave_file(const string &in filename)", asMETHOD(tone_synth, generate_file), asCALL_THISCALL);
+}

--- a/src/tonesynth.cpp
+++ b/src/tonesynth.cpp
@@ -72,16 +72,15 @@ sound* tone_synth::generate_sound() {
 		delete[] buffer;
 		return nullptr;
 	}
-	// Todo: Review rest of this function. I have no idea how the sound system operates internally so am working off logical guesses here.
 	sound *s = new_global_sound();
 	if (!s) {
 		delete[] buffer;
 		return nullptr;
 	}
 	bool loaded = s->load_pcm(buffer, static_cast<unsigned int>(size), ma_format_s16, gen->sample_rate, gen->channels);
-	delete[] buffer; // I'm assuming this is now safely copied into the sound object.
+	delete[] buffer;
 	if (!loaded) {
-		// Todo: Fix potential leak here. How would I free/release s?
+		s->release();
 		return nullptr;
 	}
 	return s;

--- a/src/tonesynth.h
+++ b/src/tonesynth.h
@@ -1,0 +1,53 @@
+/* tonesynth.h - header for the tone_synth object
+ *
+ * NVGT - NonVisual Gaming Toolkit
+ * Copyright (c) 2022-2024 Sam Tupy
+ * https://nvgt.gg
+ * This software is provided "as-is", without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+ * Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+ * 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+*/
+
+#pragma once
+
+extern "C" {
+	#include <tonar.h>
+}
+
+#include <string>
+
+#include <angelscript.h>
+
+// Forward declare a few things so they'll work.
+class sound;
+sound* new_global_sound();
+
+class tone_synth {
+public:
+	tone_synth();
+	~tone_synth();
+
+	void AddRef();
+	void Release();
+
+	void set_waveform(int type);
+	int get_waveform();
+	void set_volume(double db);
+	double get_volume();
+	void set_pan(double pan);
+	double get_pan();
+	bool set_edge_fades(int start, int end);
+	bool freq(double freq, int ms);
+	bool rest(int ms);
+	sound* generate_sound();
+	bool generate_file(const std::string& filename);
+
+private:
+	int refCount = 1;
+	el_tonar* gen = nullptr;
+};
+
+tone_synth *script_tone_synth_factory();
+void RegisterScriptTonesynth(asIScriptEngine* engine);


### PR DESCRIPTION
When I say rough, I mean rough. It works in its most raw form, but still lots to do.

1. Currently uses a system I built for C last September. I'm a beginner when it comes to audio processing, that means lots of AI help, and possibly several rooky errors. It's certainly slower than I'd like. Maybe figure out how good ma_waveform is. Does it have anti-aliasing, for instance?
2. tone_synth::generate_sound() needs an expert on the audio subsystem to review it. I'm using guesswork to assign sound objects, and I can't even find a way to free/release them, so we could be looking at a potential leak.
3. waveform types need rearranging to make them compatible with BGT's waveform types. Currently, 0=sine, 1=square, 2=triangle, 3=saw (in other words, plainest to richest).
4. There's an oversight that means a final rest() call is required to complete the sequence - this was not an issue in BGT.
5. Current functions are frequency and MS only. Musical concepts like tempo, notes, and transposition haven't yet been implemented, and I wouldn't even know where to start with reverb.
6. Signals always start from 0. While this avoids aggressive clicking at the start and end of signals, it does mean that harmonically rich signals like square and saw will click regularly due to constructive interference. We'll have to consider what tradeoff is better in the long run, unless there's another fix I haven't thought of to reduce this.

Thoughts welcome.
