### PR TITLE
Add SCRIPT_PATH property

### DIFF
--- a/src/nvgt.cpp
+++ b/src/nvgt.cpp
@@ -310,6 +310,7 @@ protected:
 			return Application::EXIT_CONFIG;
 		}
 		#endif
+		g_scriptpath = Path(scriptfile).makeParent().toString();
 		setupCommandLineProperty(args, 1);
 		g_command_line_args->InsertAt(0, (void *)&scriptfile);
 		ConfigureEngineOptions(g_ScriptEngine);

--- a/src/nvgt.h
+++ b/src/nvgt.h
@@ -22,6 +22,7 @@ extern int g_retcode;
 extern bool g_initialising_globals;
 extern bool g_shutting_down;
 extern std::string g_stub;
+extern std::string g_scriptpath;
 extern std::string g_platform;
 extern bool g_make_console;
 

--- a/src/nvgt_angelscript.cpp
+++ b/src/nvgt_angelscript.cpp
@@ -117,6 +117,7 @@ int g_retcode = 0;
 bool g_initialising_globals = true;
 bool g_shutting_down = false;
 std::string g_stub = "";
+std::string g_scriptpath = "";
 std::string g_platform = "auto";
 bool g_make_console = false;
 std::unordered_map<std::string, asITypeInfo *> g_TypeInfoCache;

--- a/src/scriptstuff.cpp
+++ b/src/scriptstuff.cpp
@@ -233,6 +233,9 @@ int get_script_current_line() {
 std::string get_script_executable() {
 	return Poco::Util::Application::instance().config().getString("application.path");
 }
+std::string get_script_path() {
+	return g_scriptpath;
+}
 std::string get_function_signature(void* function, int type_id) {
 	asIScriptContext* ctx = asGetActiveContext();
 	if (!ctx) return "";
@@ -772,6 +775,7 @@ void RegisterScriptstuff(asIScriptEngine* engine) {
 	engine->RegisterGlobalFunction("string get_SCRIPT_CURRENT_FUNCTION() property", asFUNCTION(get_script_current_function), asCALL_CDECL);
 	engine->RegisterGlobalFunction("string get_SCRIPT_CURRENT_FILE() property", asFUNCTION(get_script_current_file), asCALL_CDECL);
 	engine->RegisterGlobalFunction("int get_SCRIPT_CURRENT_LINE() property", asFUNCTION(get_script_current_line), asCALL_CDECL);
+	engine->RegisterGlobalFunction("string get_SCRIPT_MAIN_PATH() property", asFUNCTION(get_script_path), asCALL_CDECL);
 	engine->RegisterGlobalFunction("void assert(bool, const string&in = \"\")", asFUNCTION(script_assert), asCALL_CDECL);
 	engine->SetDefaultAccessMask(NVGT_SUBSYSTEM_UNCLASSIFIED);
 	engine->RegisterGlobalFunction("string get_SCRIPT_EXECUTABLE() property", asFUNCTION(get_script_executable), asCALL_CDECL);

--- a/src/scriptstuff.h
+++ b/src/scriptstuff.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <angelscript.h>
+#include "nvgt.h"
 
 bool script_compiled();
 void profiler_callback(asIScriptContext* ctx, void* obj);


### PR DESCRIPTION
Implemented a property to get the path of the main script when running from source (MAIN_SCRIPT_PATH). This makes it easy for scripts to force chdir to their own directory for asset location and so on.

Note BGT used to do this automatically, but I opted to add a property so it can be done manually in case a script needs to work from a different directory - presumably that's why cwdir and chdir were added in the first place.

Only works when running from source for now, though it's pretty simple to get the path of a compiled executable with the SCRIPT_EXECUTABLE property.
