### PR TITLE
Rp3d features

### DIFF
--- a/src/reactphysics.cpp
+++ b/src/reactphysics.cpp
@@ -602,7 +602,7 @@ void RegisterCollisionShape(asIScriptEngine* engine, const string& type) {
 	engine->RegisterObjectMethod(type.c_str(), "int get_id() const property", asMETHOD(T, getId), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "vector get_local_inertia_tensor(float mass) const", asMETHOD(T, getLocalInertiaTensor), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "float get_volume() const property", asMETHOD(T, getVolume), asCALL_THISCALL);
-	engine->RegisterObjectMethod(type.c_str(), "aabb compute_transformed_aabb(const transform&in transform) const", asMETHOD(T, computeTransformedAABB), asCALL_THISCALL);
+	engine->RegisterObjectMethod(type.c_str(), "aabb compute_transformed_aabb(const physics_transform&in transform) const", asMETHOD(T, computeTransformedAABB), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "string opImplConv() const", asMETHOD(T, to_string), asCALL_THISCALL);
 }
 
@@ -613,11 +613,11 @@ void RegisterPhysicsBody(asIScriptEngine* engine, const string& type) {
 	engine->RegisterObjectMethod(type.c_str(), "physics_entity get_entity() const property", asMETHOD(T, getEntity), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "bool get_is_active() const property", asMETHOD(T, isActive), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "void set_is_active(bool is_active) property", asMETHOD(T, setIsActive), asCALL_THISCALL);
-	engine->RegisterObjectMethod(type.c_str(), "const transform& get_transform() const property", asMETHOD(T, getTransform), asCALL_THISCALL);
-	engine->RegisterObjectMethod(type.c_str(), "void set_transform(const transform&in transform) property", asMETHOD(T, setTransform), asCALL_THISCALL);
+	engine->RegisterObjectMethod(type.c_str(), "const physics_transform& get_transform() const property", asMETHOD(T, getTransform), asCALL_THISCALL);
+	engine->RegisterObjectMethod(type.c_str(), "void set_transform(const physics_transform&in transform) property", asMETHOD(T, setTransform), asCALL_THISCALL);
 	engine->RegisterObjectMethod(
 	    type.c_str(),
-	    "physics_collider@ add_collider(physics_collision_shape@ shape, const transform&in transform)",
+	    "physics_collider@ add_collider(physics_collision_shape@ shape, const physics_transform&in transform)",
 	    asMETHOD(T, addCollider),
 	    asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "void remove_collider(physics_collider&in collider)", asMETHOD(T, removeCollider), asCALL_THISCALL);
@@ -812,26 +812,26 @@ void RegisterMathTypes(asIScriptEngine* engine) {
 	engine->RegisterGlobalFunction("quaternion quaternion_slerp(const quaternion& q1, const quaternion& q2, float t)", asFUNCTION(Quaternion::slerp), asCALL_CDECL);
 	engine->RegisterGlobalFunction("quaternion quaternion_from_euler_angles(float angle_x, float angle_y, float angle_z)", asFUNCTIONPR(Quaternion::fromEulerAngles, (decimal, decimal, decimal), Quaternion), asCALL_CDECL);
 	engine->RegisterGlobalFunction("quaternion quaternion_from_euler_angles(const vector& angles)", asFUNCTIONPR(Quaternion::fromEulerAngles, (const Vector3&), Quaternion), asCALL_CDECL);
-	engine->RegisterObjectType("transform", sizeof(Transform), asOBJ_VALUE | asOBJ_POD | asGetTypeTraits<Transform>() | asOBJ_APP_CLASS_ALLFLOATS);
-	engine->RegisterObjectBehaviour("transform", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(rp_construct<Transform>), asCALL_CDECL_OBJFIRST);
-	engine->RegisterObjectBehaviour("transform", asBEHAVE_CONSTRUCT, "void f(const vector&in position, const matrix3x3&in orientation)", asFUNCTION((rp_construct<Transform, const Vector3&, const Matrix3x3&>)), asCALL_CDECL_OBJFIRST);
-	engine->RegisterObjectBehaviour("transform", asBEHAVE_CONSTRUCT, "void f(const vector&in position, const quaternion&in orientation)", asFUNCTION((rp_construct<Transform, const Vector3&, const Quaternion&>)), asCALL_CDECL_OBJFIRST);
-	engine->RegisterObjectBehaviour("transform", asBEHAVE_DESTRUCT, "void f()", asFUNCTION(rp_destruct<Transform>), asCALL_CDECL_OBJFIRST);
-	engine->RegisterObjectMethod("transform", "const vector& get_position() const property", asMETHOD(Transform, getPosition), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "const quaternion& get_orientation() const property", asMETHOD(Transform, getOrientation), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "void set_position(const vector&in position) property", asMETHOD(Transform, setPosition), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "void set_orientation(const quaternion&in orientation) property", asMETHOD(Transform, setOrientation), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "void set_to_identity()", asMETHOD(Transform, setToIdentity), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "transform get_inverse() const property", asMETHOD(Transform, getInverse), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "bool get_is_valid() const property", asMETHOD(Transform, isValid), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "void set_from_opengl_matrix(float[]@ matrix)", asFUNCTION(transform_set_from_opengl_matrix), asCALL_CDECL_OBJFIRST);
-	engine->RegisterObjectMethod("transform", "float[]@ get_opengl_matrix() const", asFUNCTION(transform_get_opengl_matrix), asCALL_CDECL_OBJFIRST);
-	engine->RegisterObjectMethod("transform", "bool opEquals(const transform&in) const", asMETHOD(Transform, operator==), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "transform opMul(const transform&in) const", asMETHODPR(Transform, operator*, (const Transform&) const, Transform), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "vector opMul(const vector&in) const", asMETHODPR(Transform, operator*, (const Vector3&) const, Vector3), asCALL_THISCALL);
-	engine->RegisterObjectMethod("transform", "string opImplConv()", asMETHOD(Transform, to_string), asCALL_THISCALL);
-	engine->RegisterGlobalFunction("transform get_IDENTITY_TRANSFORM() property", asFUNCTION(Transform::identity), asCALL_CDECL);
-	engine->RegisterGlobalFunction("transform transforms_interpolate()", asFUNCTION(Transform::interpolateTransforms), asCALL_CDECL);
+	engine->RegisterObjectType("physics_transform", sizeof(Transform), asOBJ_VALUE | asOBJ_POD | asGetTypeTraits<Transform>() | asOBJ_APP_CLASS_ALLFLOATS);
+	engine->RegisterObjectBehaviour("physics_transform", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(rp_construct<Transform>), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectBehaviour("physics_transform", asBEHAVE_CONSTRUCT, "void f(const vector&in position, const matrix3x3&in orientation)", asFUNCTION((rp_construct<Transform, const Vector3&, const Matrix3x3&>)), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectBehaviour("physics_transform", asBEHAVE_CONSTRUCT, "void f(const vector&in position, const quaternion&in orientation)", asFUNCTION((rp_construct<Transform, const Vector3&, const Quaternion&>)), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectBehaviour("physics_transform", asBEHAVE_DESTRUCT, "void f()", asFUNCTION(rp_destruct<Transform>), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectMethod("physics_transform", "const vector& get_position() const property", asMETHOD(Transform, getPosition), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "const quaternion& get_orientation() const property", asMETHOD(Transform, getOrientation), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "void set_position(const vector&in position) property", asMETHOD(Transform, setPosition), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "void set_orientation(const quaternion&in orientation) property", asMETHOD(Transform, setOrientation), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "void set_to_identity()", asMETHOD(Transform, setToIdentity), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "physics_transform get_inverse() const property", asMETHOD(Transform, getInverse), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "bool get_is_valid() const property", asMETHOD(Transform, isValid), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "void set_from_opengl_matrix(float[]@ matrix)", asFUNCTION(transform_set_from_opengl_matrix), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectMethod("physics_transform", "float[]@ get_opengl_matrix() const", asFUNCTION(transform_get_opengl_matrix), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectMethod("physics_transform", "bool opEquals(const physics_transform&in) const", asMETHOD(Transform, operator==), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "physics_transform opMul(const physics_transform&in) const", asMETHODPR(Transform, operator*, (const Transform&) const, Transform), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "vector opMul(const vector&in) const", asMETHODPR(Transform, operator*, (const Vector3&) const, Vector3), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_transform", "string opImplConv()", asMETHOD(Transform, to_string), asCALL_THISCALL);
+	engine->RegisterGlobalFunction("physics_transform get_IDENTITY_TRANSFORM() property", asFUNCTION(Transform::identity), asCALL_CDECL);
+	engine->RegisterGlobalFunction("physics_transform transforms_interpolate()", asFUNCTION(Transform::interpolateTransforms), asCALL_CDECL);
 }
 
 void RegisterCorePhysicsTypes(asIScriptEngine* engine) {
@@ -918,9 +918,9 @@ void RegisterPhysicsEntities(asIScriptEngine* engine) {
 	engine->RegisterObjectMethod("physics_collider", "physics_collision_shape@ get_collision_shape() property", asMETHODPR(Collider, getCollisionShape, (), CollisionShape*), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_collider", "const physics_collision_shape@ get_collision_shape() const property", asMETHODPR(Collider, getCollisionShape, () const, const CollisionShape*), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_collider", "physics_body@ get_body() const property", asMETHOD(Collider, getBody), asCALL_THISCALL);
-	engine->RegisterObjectMethod("physics_collider", "const transform& get_local_to_body_transform() const property", asMETHOD(Collider, getLocalToBodyTransform), asCALL_THISCALL);
-	engine->RegisterObjectMethod("physics_collider", "void set_local_to_body_transform(const transform&in transform) property", asMETHOD(Collider, setLocalToBodyTransform), asCALL_THISCALL);
-	engine->RegisterObjectMethod("physics_collider", "const transform get_local_to_world_transform() const", asMETHOD(Collider, getLocalToWorldTransform), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_collider", "const physics_transform& get_local_to_body_transform() const property", asMETHOD(Collider, getLocalToBodyTransform), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_collider", "void set_local_to_body_transform(const physics_transform&in transform) property", asMETHOD(Collider, setLocalToBodyTransform), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_collider", "const physics_transform get_local_to_world_transform() const", asMETHOD(Collider, getLocalToWorldTransform), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_collider", "const aabb get_world_aabb() const property", asMETHOD(Collider, getWorldAABB), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_collider", "bool test_aabb_overlap(const aabb&in world_aabb) const", asMETHOD(Collider, testAABBOverlap), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_collider", "bool test_point_inside(const vector&in world_point)", asMETHOD(Collider, testPointInside), asCALL_THISCALL);
@@ -994,7 +994,7 @@ void RegisterCollisionShapes(asIScriptEngine* engine) {
 	RegisterConvexPolyhedronShape<TriangleShape>(engine, "physics_triangle_shape");
 	engine->RegisterObjectMethod("physics_triangle_shape", "physics_triangle_raycast_side get_raycast_test_type() const property", asMETHOD(TriangleShape, getRaycastTestType), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_triangle_shape", "void set_raycast_test_type(physics_triangle_raycast_side test_type) property", asMETHOD(TriangleShape, setRaycastTestType), asCALL_THISCALL);
-	engine->RegisterGlobalFunction("void physics_triangle_shape_compute_smooth_triangle_mesh_contact(const physics_collision_shape &in shape1, const physics_collision_shape &in shape2, vector & local_contact_point_shape1, vector & local_contact_point_shape2, const transform &in shape1_to_world, const transform &in shape2_to_world, float penitration_depth, vector & out_smooth_vertex_normal)", asFUNCTION(TriangleShape::computeSmoothTriangleMeshContact), asCALL_CDECL);
+	engine->RegisterGlobalFunction("void physics_triangle_shape_compute_smooth_triangle_mesh_contact(const physics_collision_shape &in shape1, const physics_collision_shape &in shape2, vector & local_contact_point_shape1, vector & local_contact_point_shape2, const physics_transform &in shape1_to_world, const physics_transform &in shape2_to_world, float penitration_depth, vector & out_smooth_vertex_normal)", asFUNCTION(TriangleShape::computeSmoothTriangleMeshContact), asCALL_CDECL);
 	RegisterConvexPolyhedronShape<ConvexMeshShape>(engine, "physics_convex_mesh_shape");
 	engine->RegisterObjectMethod("physics_convex_mesh_shape", "vector& get_scale() const property", asMETHOD(ConvexMeshShape, getScale), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_convex_mesh_shape", "void set_scale(vector& scale) const property", asMETHOD(ConvexMeshShape, setScale), asCALL_THISCALL);
@@ -1193,7 +1193,7 @@ void RegisterPhysicsWorldAndCallbacks(asIScriptEngine* engine) {
 	engine->RegisterObjectMethod("physics_world", "uint16 get_nb_iterations_position_solver() const property", asMETHOD(PhysicsWorld, getNbIterationsPositionSolver), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_world", "void set_nb_iterations_position_solver(uint16 iterations) property", asMETHOD(PhysicsWorld, setNbIterationsPositionSolver), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_world", "void set_contacts_position_correction_technique(physics_contact_position_correction_technique technique) property", asMETHOD(PhysicsWorld, setContactsPositionCorrectionTechnique), asCALL_THISCALL);
-	engine->RegisterObjectMethod("physics_world", "physics_rigid_body@ create_rigid_body(const transform&in transform)", asMETHOD(PhysicsWorld, createRigidBody), asCALL_THISCALL);
+	engine->RegisterObjectMethod("physics_world", "physics_rigid_body@ create_rigid_body(const physics_transform&in transform)", asMETHOD(PhysicsWorld, createRigidBody), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_world", "void destroy_rigid_body(physics_rigid_body& body)", asMETHOD(PhysicsWorld, destroyRigidBody), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_world", "physics_joint@ create_joint(const physics_joint_info&in joint_info)", asMETHOD(PhysicsWorld, createJoint), asCALL_THISCALL);
 	engine->RegisterObjectMethod("physics_world", "void destroy_joint(physics_joint& joint)", asMETHOD(PhysicsWorld, destroyJoint), asCALL_THISCALL);

--- a/src/reactphysics.cpp
+++ b/src/reactphysics.cpp
@@ -240,7 +240,7 @@ void default_logger_destroy(DefaultLogger* logger) {
  * correct destroy function based on the shape's runtime type information.
  * This eliminates the need for users to know the specific shape type when
  * destroying shapes.
- */
+*/
 void physics_shape_destroy(CollisionShape* shape) {
 	if (!shape)
 		return;
@@ -609,20 +609,13 @@ HeightField* create_height_field_float(int nbGridColumns, int nbGridRows, CScrip
 	if (!heightData) throw std::runtime_error("Height data array cannot be null");
 	uint32 expectedSize = nbGridColumns * nbGridRows;
 	if (heightData->GetSize() != expectedSize) {
-		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) +
-		                         ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
+		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) + ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
 	}
 	std::vector<float> heightBuffer(expectedSize);
 	for (uint32 i = 0; i < expectedSize; i++)
 		heightBuffer[i] = *(float*)heightData->At(i);
 	std::vector<Message> messages;
-	HeightField* heightField = g_physics.createHeightField(
-	                               nbGridColumns,
-	                               nbGridRows,
-	                               heightBuffer.data(),
-	                               HeightField::HeightDataType::HEIGHT_FLOAT_TYPE,
-	                               messages,
-	                               integerHeightScale);
+	HeightField* heightField = g_physics.createHeightField(nbGridColumns, nbGridRows, heightBuffer.data(), HeightField::HeightDataType::HEIGHT_FLOAT_TYPE, messages, integerHeightScale);
 	// TODO: Handle messages - could expose them to script or log them
 	return heightField;
 }
@@ -631,20 +624,13 @@ HeightField* create_height_field_int(int nbGridColumns, int nbGridRows, CScriptA
 	if (!heightData) throw std::runtime_error("Height data array cannot be null");
 	uint32 expectedSize = nbGridColumns * nbGridRows;
 	if (heightData->GetSize() != expectedSize) {
-		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) +
-		                         ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
+		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) + ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
 	}
 	std::vector<int> heightBuffer(expectedSize);
 	for (uint32 i = 0; i < expectedSize; i++)
 		heightBuffer[i] = *(int*)heightData->At(i);
 	std::vector<Message> messages;
-	HeightField* heightField = g_physics.createHeightField(
-	                               nbGridColumns,
-	                               nbGridRows,
-	                               heightBuffer.data(),
-	                               HeightField::HeightDataType::HEIGHT_INT_TYPE,
-	                               messages,
-	                               integerHeightScale);
+	HeightField* heightField = g_physics.createHeightField(nbGridColumns, nbGridRows, heightBuffer.data(), HeightField::HeightDataType::HEIGHT_INT_TYPE, messages, integerHeightScale);
 	return heightField;
 }
 
@@ -652,20 +638,13 @@ HeightField* create_height_field_double(int nbGridColumns, int nbGridRows, CScri
 	if (!heightData) throw std::runtime_error("Height data array cannot be null");
 	uint32 expectedSize = nbGridColumns * nbGridRows;
 	if (heightData->GetSize() != expectedSize) {
-		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) +
-		                         ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
+		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) + ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
 	}
 	std::vector<double> heightBuffer(expectedSize);
 	for (uint32 i = 0; i < expectedSize; i++)
 		heightBuffer[i] = *(double*)heightData->At(i);
 	std::vector<Message> messages;
-	HeightField* heightField = g_physics.createHeightField(
-	                               nbGridColumns,
-	                               nbGridRows,
-	                               heightBuffer.data(),
-	                               HeightField::HeightDataType::HEIGHT_DOUBLE_TYPE,
-	                               messages,
-	                               integerHeightScale);
+	HeightField* heightField = g_physics.createHeightField(nbGridColumns, nbGridRows, heightBuffer.data(), HeightField::HeightDataType::HEIGHT_DOUBLE_TYPE, messages, integerHeightScale);
 	return heightField;
 }
 
@@ -1439,8 +1418,7 @@ void RegisterPhysicsCommonFactories(asIScriptEngine* engine) {
 	engine->RegisterGlobalFunction("void physics_concave_mesh_shape_destroy(physics_concave_mesh_shape@ shape)", asFUNCTION(concave_mesh_shape_destroy), asCALL_CDECL);
 	engine->RegisterGlobalFunction("void physics_convex_mesh_destroy(physics_convex_mesh@ mesh)", asFUNCTION(convex_mesh_destroy), asCALL_CDECL);
 	// Generic global destroy
-	engine->RegisterGlobalFunction("void physics_shape_destroy(physics_collision_shape@ shape)",
-	                               asFUNCTION(physics_shape_destroy), asCALL_CDECL);
+	engine->RegisterGlobalFunction("void physics_shape_destroy(physics_collision_shape@ shape)", asFUNCTION(physics_shape_destroy), asCALL_CDECL);
 	engine->RegisterGlobalFunction("void physics_height_field_destroy(physics_height_field@ height_field)", asFUNCTION(height_field_destroy), asCALL_CDECL);
 }
 

--- a/src/reactphysics.cpp
+++ b/src/reactphysics.cpp
@@ -614,6 +614,70 @@ void world_destroy_rigid_body(PhysicsWorld* world, RigidBody* body) {
 	world->destroyRigidBody(body);
 }
 
+HeightField* create_height_field_float(int nbGridColumns, int nbGridRows, CScriptArray* heightData, decimal integerHeightScale) {
+	if (!heightData) throw std::runtime_error("Height data array cannot be null");
+	uint32 expectedSize = nbGridColumns * nbGridRows;
+	if (heightData->GetSize() != expectedSize) {
+		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) +
+		                         ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
+	}
+	std::vector<float> heightBuffer(expectedSize);
+	for (uint32 i = 0; i < expectedSize; i++)
+		heightBuffer[i] = *(float*)heightData->At(i);
+	std::vector<Message> messages;
+	HeightField* heightField = g_physics.createHeightField(
+	                               nbGridColumns,
+	                               nbGridRows,
+	                               heightBuffer.data(),
+	                               HeightField::HeightDataType::HEIGHT_FLOAT_TYPE,
+	                               messages,
+	                               integerHeightScale);
+	// TODO: Handle messages - could expose them to script or log them
+	return heightField;
+}
+
+HeightField* create_height_field_int(int nbGridColumns, int nbGridRows, CScriptArray* heightData, decimal integerHeightScale) {
+	if (!heightData) throw std::runtime_error("Height data array cannot be null");
+	uint32 expectedSize = nbGridColumns * nbGridRows;
+	if (heightData->GetSize() != expectedSize) {
+		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) +
+		                         ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
+	}
+	std::vector<int> heightBuffer(expectedSize);
+	for (uint32 i = 0; i < expectedSize; i++)
+		heightBuffer[i] = *(int*)heightData->At(i);
+	std::vector<Message> messages;
+	HeightField* heightField = g_physics.createHeightField(
+	                               nbGridColumns,
+	                               nbGridRows,
+	                               heightBuffer.data(),
+	                               HeightField::HeightDataType::HEIGHT_INT_TYPE,
+	                               messages,
+	                               integerHeightScale);
+	return heightField;
+}
+
+HeightField* create_height_field_double(int nbGridColumns, int nbGridRows, CScriptArray* heightData, decimal integerHeightScale) {
+	if (!heightData) throw std::runtime_error("Height data array cannot be null");
+	uint32 expectedSize = nbGridColumns * nbGridRows;
+	if (heightData->GetSize() != expectedSize) {
+		throw std::runtime_error("Height data array size (" + std::to_string(heightData->GetSize()) +
+		                         ") must match grid dimensions (" + std::to_string(expectedSize) + ")");
+	}
+	std::vector<double> heightBuffer(expectedSize);
+	for (uint32 i = 0; i < expectedSize; i++)
+		heightBuffer[i] = *(double*)heightData->At(i);
+	std::vector<Message> messages;
+	HeightField* heightField = g_physics.createHeightField(
+	                               nbGridColumns,
+	                               nbGridRows,
+	                               heightBuffer.data(),
+	                               HeightField::HeightDataType::HEIGHT_DOUBLE_TYPE,
+	                               messages,
+	                               integerHeightScale);
+	return heightField;
+}
+
 // Registration templates
 template <class T>
 void RegisterCollisionShape(asIScriptEngine* engine, const string& type) {
@@ -1310,6 +1374,9 @@ void RegisterPhysicsCommonFactories(asIScriptEngine* engine) {
 	engine->RegisterGlobalFunction("physics_triangle_mesh@ physics_triangle_mesh_create(physics_triangle_data@ triangle_data)", asFUNCTION(create_triangle_mesh_from_managed), asCALL_CDECL);
 	engine->RegisterGlobalFunction("physics_convex_mesh@ physics_convex_mesh_create(physics_vertex_data@ vertex_data)", asFUNCTION(create_convex_mesh_from_managed_vertex_array), asCALL_CDECL);
 	engine->RegisterGlobalFunction("physics_convex_mesh@ physics_convex_mesh_create_from_polygon(physics_polygon_data@ polygon_data)", asFUNCTION(create_convex_mesh_from_polygon_data), asCALL_CDECL);
+	engine->RegisterGlobalFunction("physics_height_field@ physics_height_field_create(int nb_columns, int nb_rows, float[]@ height_data, float integer_height_scale = 1.0f)", asFUNCTION(create_height_field_float), asCALL_CDECL);
+	engine->RegisterGlobalFunction("physics_height_field@ physics_height_field_create(int nb_columns, int nb_rows, int[]@ height_data, float integer_height_scale = 1.0f)", asFUNCTION(create_height_field_int), asCALL_CDECL);
+	engine->RegisterGlobalFunction("physics_height_field@ physics_height_field_create(int nb_columns, int nb_rows, double[]@ height_data, float integer_height_scale = 1.0f)", asFUNCTION(create_height_field_double), asCALL_CDECL);
 	// Shape destruction functions
 	engine->RegisterGlobalFunction("void physics_sphere_shape_destroy(physics_sphere_shape@ shape)", asFUNCTION(sphere_shape_destroy), asCALL_CDECL);
 	engine->RegisterGlobalFunction("void physics_box_shape_destroy(physics_box_shape@ shape)", asFUNCTION(box_shape_destroy), asCALL_CDECL);
@@ -1322,6 +1389,7 @@ void RegisterPhysicsCommonFactories(asIScriptEngine* engine) {
 	// Generic global destroy
 	engine->RegisterGlobalFunction("void physics_shape_destroy(physics_collision_shape@ shape)",
 	                               asFUNCTION(physics_shape_destroy), asCALL_CDECL);
+	engine->RegisterGlobalFunction("void physics_height_field_destroy(physics_height_field@ height_field)", asFUNCTION(height_field_destroy), asCALL_CDECL);
 }
 
 void RegisterShapeConversions(asIScriptEngine* engine) {

--- a/src/reactphysics.cpp
+++ b/src/reactphysics.cpp
@@ -26,7 +26,7 @@ using namespace reactphysics3d;
 class event_listener;
 
 PhysicsCommon g_physics;
-unordered_map<PhysicsWorld*, event_listener*> g_physics_event_listeners; // These need to be kept alive while the world exists, and the PhysicsWorld class has no user data.
+unordered_map<PhysicsWorld*, event_listener*> g_physics_event_listeners;  // These need to be kept alive while the world exists, and the PhysicsWorld class has no user data.
 
 // Angelscript factories.
 template <class T, typename... A>

--- a/src/reactphysics.cpp
+++ b/src/reactphysics.cpp
@@ -615,7 +615,11 @@ void RegisterPhysicsBody(asIScriptEngine* engine, const string& type) {
 	engine->RegisterObjectMethod(type.c_str(), "void set_is_active(bool is_active) property", asMETHOD(T, setIsActive), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "const transform& get_transform() const property", asMETHOD(T, getTransform), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "void set_transform(const transform&in transform) property", asMETHOD(T, setTransform), asCALL_THISCALL);
-	engine->RegisterObjectMethod(type.c_str(), "physics_collider@ add_collider(physics_collision_shape&in shape, const transform&in transform)", asMETHOD(T, addCollider), asCALL_THISCALL);
+	engine->RegisterObjectMethod(
+	    type.c_str(),
+	    "physics_collider@ add_collider(physics_collision_shape@ shape, const transform&in transform)",
+	    asMETHOD(T, addCollider),
+	    asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "void remove_collider(physics_collider&in collider)", asMETHOD(T, removeCollider), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "bool test_point_inside(const vector&in point) const", asMETHOD(T, testPointInside), asCALL_THISCALL);
 	engine->RegisterObjectMethod(type.c_str(), "bool raycast(const ray& point, raycast_info& raycast_info) const", asMETHOD(T, raycast), asCALL_THISCALL);

--- a/test/quick/rp3d.nvgt
+++ b/test/quick/rp3d.nvgt
@@ -7,7 +7,7 @@ void main() {
 	aabb box(vector(0, 0, 0), vector(10, 10, 10));
 	alert(EPSILON, box.extent);
 	float[]@ matrix = IDENTITY_TRANSFORM.get_opengl_matrix();
-	transform tr;
+	physics_transform tr;
 	tr.set_from_opengl_matrix(matrix);
 	alert(tr == IDENTITY_TRANSFORM, string(matrix));
 }

--- a/test/quick/rp3d_2.nvgt
+++ b/test/quick/rp3d_2.nvgt
@@ -19,11 +19,11 @@ void main() {
     println("Identity quaternion: ", string(q1));
 
     // Transforms
-    transform t1;
+    physics_transform t1;
     t1.set_to_identity();
     println("Identity transform position: ", string(t1.get_position()));
 
-    transform t2(vector(1, 2, 3), q1);
+    physics_transform t2(vector(1, 2, 3), q1);
     println("Transform with position (1,2,3): ", string(t2.get_position()));
 
     // AABB
@@ -51,7 +51,7 @@ void main() {
     println("Gravity enabled: ", world.get_is_gravity_enabled());
 
     // Create a simple rigid body (without shapes for now)
-    transform bodyTransform(vector(0, 5, 0), get_IDENTITY_QUATERNION());
+    physics_transform bodyTransform(vector(0, 5, 0), get_IDENTITY_QUATERNION());
     physics_rigid_body@ body = world.create_rigid_body(bodyTransform);
     body.set_type(PHYSICS_BODY_DYNAMIC);
     body.set_mass(1.0);

--- a/test/quick/rp3d_basic_sim.nvgt
+++ b/test/quick/rp3d_basic_sim.nvgt
@@ -10,17 +10,17 @@ void main() {
     physics_box_shape@ groundShape = physics_box_shape(vector(10, 0.5f, 10));  // 20x1x20 ground
 
     // Create a dynamic sphere that will fall
-    transform sphereTransform(vector(0, 10, 0), IDENTITY_QUATERNION);  // 10 units above ground
+    physics_transform sphereTransform(vector(0, 10, 0), IDENTITY_QUATERNION);  // 10 units above ground
     physics_rigid_body@ sphere = world.create_rigid_body(sphereTransform);
     sphere.set_type(PHYSICS_BODY_DYNAMIC);  // Make it dynamic so it falls
     sphere.set_mass(1.0f);
 
     // Add collider to sphere
-    transform localTransform = IDENTITY_TRANSFORM;
+    physics_transform localTransform = IDENTITY_TRANSFORM;
     physics_collider@ sphereCollider = sphere.add_collider(sphereShape, localTransform);
 
     // Create a static ground
-    transform groundTransform(vector(0, -0.5f, 0), IDENTITY_QUATERNION);  // Ground at y = -0.5
+    physics_transform groundTransform(vector(0, -0.5f, 0), IDENTITY_QUATERNION);  // Ground at y = -0.5
     physics_rigid_body@ ground = world.create_rigid_body(groundTransform);
     ground.set_type(PHYSICS_BODY_STATIC);  // Static so it doesn't move
 
@@ -35,7 +35,7 @@ void main() {
         // Update physics world
         world.update(timeStep);
 
-        transform spherePos = sphere.get_transform();
+        physics_transform spherePos = sphere.get_transform();
         vector pos = spherePos.get_position();
 
         if (i % 60 == 0) {  // Print every second

--- a/test/quick/rp3d_basic_sim_collision_callbacks.nvgt
+++ b/test/quick/rp3d_basic_sim_collision_callbacks.nvgt
@@ -10,17 +10,17 @@ void main() {
     physics_box_shape@ groundShape = physics_box_shape(vector(10, 0.5f, 10));  // 20x1x20 ground
 
     // Create a dynamic sphere that will fall
-    transform sphereTransform(vector(0, 10, 0), IDENTITY_QUATERNION);  // 10 units above ground
+    physics_transform sphereTransform(vector(0, 10, 0), IDENTITY_QUATERNION);  // 10 units above ground
     physics_rigid_body@ sphere = world.create_rigid_body(sphereTransform);
     sphere.set_type(PHYSICS_BODY_DYNAMIC);  // Make it dynamic so it falls
     sphere.set_mass(1.0f);
 
     // Add collider to sphere
-    transform localTransform = IDENTITY_TRANSFORM;
+    physics_transform localTransform = IDENTITY_TRANSFORM;
     physics_collider@ sphereCollider = sphere.add_collider(sphereShape, localTransform);
 
     // Create a static ground
-    transform groundTransform(vector(0, -0.5f, 0), IDENTITY_QUATERNION);  // Ground at y = -0.5
+    physics_transform groundTransform(vector(0, -0.5f, 0), IDENTITY_QUATERNION);  // Ground at y = -0.5
     physics_rigid_body@ ground = world.create_rigid_body(groundTransform);
     ground.set_type(PHYSICS_BODY_STATIC);  // Static so it doesn't move
 
@@ -37,7 +37,7 @@ void main() {
         // Update physics world
         world.update(timeStep);
 
-        transform spherePos = sphere.get_transform();
+        physics_transform spherePos = sphere.get_transform();
         vector pos = spherePos.get_position();
 
         if (i % 60 == 0) {  // Print every second

--- a/test/quick/rp3d_height_field.nvgt
+++ b/test/quick/rp3d_height_field.nvgt
@@ -1,0 +1,127 @@
+void main() {
+    physics_world_settings settings;
+    settings.world_name = "Height Field World";
+    physics_world@ world = physics_world(settings);
+
+    // Create a 4x4 grid of height values (16 total values)
+    // Heights represent a small hill in the center
+    float[] floatHeights = {
+        0.0f, 0.1f, 0.1f, 0.0f,  // Row 0
+        0.1f, 0.5f, 0.5f, 0.1f,  // Row 1
+        0.1f, 0.5f, 0.5f, 0.1f,  // Row 2
+        0.0f, 0.1f, 0.1f, 0.0f   // Row 3
+    };
+
+    int columns = 4;
+    int rows = 4;
+
+    physics_height_field@ floatField = physics_height_field_create(columns, rows, floatHeights);
+    println("Created float height field - Columns: " + floatField.nb_columns + ", Rows: " + floatField.nb_rows);
+    println("Min height: " + floatField.min_height + ", Max height: " + floatField.max_height);
+
+    // Create height field shape
+    vector scaling(2.0f, 1.0f, 2.0f);  // Scale X and Z by 2, keep Y as 1
+    physics_height_field_shape@ floatShape = physics_height_field_shape(floatField, scaling);
+
+    physics_transform transform;
+    transform.position = vector(0, -2, 0);  // Place below origin
+    physics_rigid_body@ terrainBody = world.create_rigid_body(transform);
+    terrainBody.type = PHYSICS_BODY_STATIC;  // Terrain should be static
+
+    physics_collider@ terrainCollider = terrainBody.add_collider(floatShape, physics_transform());
+    println("Added height field to terrain body");
+
+    println("Sample vertex at (0,0): " + floatField.get_vertex_at(0, 0).x + "," + floatField.get_vertex_at(0, 0).y + "," + floatField.get_vertex_at(0, 0).z);
+    println("Sample vertex at (1,1): " + floatField.get_vertex_at(1, 1).x + "," + floatField.get_vertex_at(1, 1).y + "," + floatField.get_vertex_at(1, 1).z);
+
+    // Create integer height data (will be scaled by integerHeightScale)
+    int[] intHeights = {
+        0, 5, 10, 5, 0,
+        5, 15, 25, 15, 5,
+        10, 25, 40, 25, 10,
+        5, 15, 25, 15, 5,
+        0, 5, 10, 5, 0
+    };
+
+    float integerScale = 0.1f;  // Each integer unit = 0.1 world units
+    physics_height_field@ intField = physics_height_field_create(5, 5, intHeights, integerScale);
+    println("Created integer height field - Columns: " + intField.nb_columns + ", Rows: " + intField.nb_rows);
+    println("Integer height scale: " + intField.integer_height_scale);
+    println("Min height: " + intField.min_height + ", Max height: " + intField.max_height);
+
+    physics_height_field_shape@ intShape = physics_height_field_shape(intField);
+
+    double[] doubleHeights = {
+        0.0, 0.25, 0.0,
+        0.25, 1.0, 0.25,
+        0.0, 0.25, 0.0
+    };
+
+    physics_height_field@ doubleField = physics_height_field_create(3, 3, doubleHeights);
+    println("Created double height field - Columns: " + doubleField.nb_columns + ", Rows: " + doubleField.nb_rows);
+    println("Data type: " + doubleField.height_data_type);
+
+    for (int row = 0; row < 3; row++) {
+        for (int col = 0; col < 3; col++) {
+            float height = doubleField.get_height_at(col, row);
+            println("Height at (" + col + "," + row + "): " + height);
+        }
+    }
+
+    aabb bounds = doubleField.bounds;
+    println("Height field bounds - Min: " + bounds.min.x + "," + bounds.min.y + "," + bounds.min.z);
+    println("Height field bounds - Max: " + bounds.max.x + "," + bounds.max.y + "," + bounds.max.z);
+
+    physics_transform dynamicTransform;
+    dynamicTransform.position = vector(0, 5, 0);  // Start above terrain
+    physics_rigid_body@ dynamicBody = world.create_rigid_body(dynamicTransform);
+    dynamicBody.type = PHYSICS_BODY_DYNAMIC;
+
+    physics_sphere_shape@ sphere = physics_sphere_shape(0.5f);
+    physics_collider@ sphereCollider = dynamicBody.add_collider(sphere, physics_transform());
+
+    println("Created dynamic sphere body above terrain");
+
+    println("Float height shape type: " + floatShape.type);
+    println("Float height shape name: " + floatShape.name);
+    println("Is convex: " + floatShape.is_convex);
+    println("Is polyhedron: " + floatShape.is_polyhedron);
+    println("Volume: " + floatShape.volume);
+
+    println("Raycast test type: " + floatShape.raycast_test_type);
+    floatShape.raycast_test_type = TRIANGLE_RAYCAST_SIDE_FRONT_AND_BACK;
+    println("Updated raycast test type: " + floatShape.raycast_test_type);
+
+    // Try to create with mismatched dimensions
+    float[] badHeights = { 1.0f, 2.0f, 3.0f };  // Only 3 values
+    try {
+        physics_height_field@ badField = physics_height_field_create(4, 4, badHeights);  // Expects 16 values
+        println("ERROR: Should have failed!");
+    } catch {
+        println("Correctly caught dimension mismatch error");
+    }
+
+    aabb terrainAABB = terrainBody.aabb;
+    println("Terrain body AABB - Min: " + terrainAABB.min.x + "," + terrainAABB.min.y + "," + terrainAABB.min.z);
+    println("Terrain body AABB - Max: " + terrainAABB.max.x + "," + terrainAABB.max.y + "," + terrainAABB.max.z);
+
+    bool overlaps = terrainBody.test_aabb_overlap(dynamicBody.aabb);
+    println("Terrain overlaps with sphere: " + overlaps);
+
+    // Bodies must go first; they own stuff like colliders and reference shapes
+    world.destroy_rigid_body(terrainBody);
+    world.destroy_rigid_body(dynamicBody);
+
+    // Destroy shapes (after bodies that reference them are gone)
+    physics_sphere_shape_destroy(sphere);
+    physics_height_field_shape_destroy(floatShape);
+    physics_height_field_shape_destroy(intShape);
+
+    // Destroy height fields (after height field shapes are destroyed)
+    physics_height_field_destroy(floatField);
+    physics_height_field_destroy(intField);
+    physics_height_field_destroy(doubleField);
+
+    // Destroy the physics world
+    physics_world_destroy(world);
+}

--- a/test/quick/rp3d_logger.nvgt
+++ b/test/quick/rp3d_logger.nvgt
@@ -1,0 +1,153 @@
+void main() {
+    
+    physics_default_logger@ defaultLogger = physics_default_logger_create();
+    if (defaultLogger !is null) {
+        println("Default logger created successfully");
+    } else {
+        println("Failed to create default logger");
+        return;
+    }
+
+    uint allLevels = LOGGER_LEVEL_ERROR | LOGGER_LEVEL_WARNING | LOGGER_LEVEL_INFORMATION;
+    defaultLogger.add_file_destination("physics_full.log", allLevels, LOGGER_FORMAT_TEXT);
+    println("Added text file destination for all log levels");
+
+    uint errorsAndWarnings = LOGGER_LEVEL_ERROR | LOGGER_LEVEL_WARNING;
+    defaultLogger.add_file_destination("physics_errors.html", errorsAndWarnings, LOGGER_FORMAT_HTML);
+    println("Added HTML file destination for errors and warnings");
+
+    defaultLogger.add_file_destination("physics_info.log", LOGGER_LEVEL_INFORMATION, LOGGER_FORMAT_TEXT);
+    println("Added text file destination for information only");
+
+    physics_logger@ baseLogger = defaultLogger; // Uses opImplCast
+
+    physics_logger@ currentBefore = physics_logger_get_current();
+    if (currentBefore is null) {
+        println("No current logger set initially");
+    } else {
+        println("Current logger was already set");
+    }
+
+    physics_logger_set_current(baseLogger);
+    println("Set logger as global logger");
+
+    physics_logger@ currentAfter = physics_logger_get_current();
+    if (currentAfter !is null) {
+        println("Global logger is now set");
+    } else {
+        println("✗ Failed to set global logger");
+    }
+
+    string categoryPhysics = physics_logger_get_category_name(LOGGER_CATEGORY_PHYSICS_COMMON);
+    string categoryWorld = physics_logger_get_category_name(LOGGER_CATEGORY_WORLD);
+    string categoryBody = physics_logger_get_category_name(LOGGER_CATEGORY_BODY);
+    string categoryJoint = physics_logger_get_category_name(LOGGER_CATEGORY_JOINT);
+    string categoryCollider = physics_logger_get_category_name(LOGGER_CATEGORY_COLLIDER);
+
+    println("Category names:");
+    println("  PHYSICS_COMMON: '" + categoryPhysics + "'");
+    println("  WORLD: '" + categoryWorld + "'");
+    println("  BODY: '" + categoryBody + "'");
+    println("  JOINT: '" + categoryJoint + "'");
+    println("  COLLIDER: '" + categoryCollider + "'");
+
+    string levelError = physics_logger_get_level_name(LOGGER_LEVEL_ERROR);
+    string levelWarning = physics_logger_get_level_name(LOGGER_LEVEL_WARNING);
+    string levelInfo = physics_logger_get_level_name(LOGGER_LEVEL_INFORMATION);
+
+    println("Level names:");
+    println("  ERROR: '" + levelError + "'");
+    println("  WARNING: '" + levelWarning + "'");
+    println("  INFORMATION: '" + levelInfo + "'");
+
+    string worldName = "DemoWorld";
+
+    println("Logging information messages...");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, worldName, LOGGER_CATEGORY_PHYSICS_COMMON, "Physics system initialized successfully");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, worldName, LOGGER_CATEGORY_WORLD, "Physics world created with default settings");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, worldName, LOGGER_CATEGORY_BODY, "Rigid body added to simulation");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, worldName, LOGGER_CATEGORY_JOINT, "Joint constraint applied between bodies");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, worldName, LOGGER_CATEGORY_COLLIDER, "Collider shape created and attached");
+
+    println("Logging warning messages...");
+    baseLogger.log(LOGGER_LEVEL_WARNING, worldName, LOGGER_CATEGORY_WORLD, "Simulation timestep is very large, may cause instability");
+    baseLogger.log(LOGGER_LEVEL_WARNING, worldName, LOGGER_CATEGORY_BODY, "Body mass is extremely small, physics may be unstable");
+    baseLogger.log(LOGGER_LEVEL_WARNING, worldName, LOGGER_CATEGORY_JOINT, "Joint limits are very restrictive");
+    baseLogger.log(LOGGER_LEVEL_WARNING, worldName, LOGGER_CATEGORY_COLLIDER, "Collider scale factor is very small");
+
+    println("Logging error messages...");
+    baseLogger.log(LOGGER_LEVEL_ERROR, worldName, LOGGER_CATEGORY_PHYSICS_COMMON, "Failed to allocate memory for physics simulation");
+    baseLogger.log(LOGGER_LEVEL_ERROR, worldName, LOGGER_CATEGORY_WORLD, "World step failed due to invalid configuration");
+    baseLogger.log(LOGGER_LEVEL_ERROR, worldName, LOGGER_CATEGORY_BODY, "Invalid body type specified during creation");
+    baseLogger.log(LOGGER_LEVEL_ERROR, worldName, LOGGER_CATEGORY_JOINT, "Joint creation failed - invalid anchor points");
+    baseLogger.log(LOGGER_LEVEL_ERROR, worldName, LOGGER_CATEGORY_COLLIDER, "Collider shape is null or invalid");
+
+    physics_default_logger@ secondLogger = physics_default_logger_create();
+    if (secondLogger !is null) {
+        println("Created second logger");
+
+        secondLogger.add_file_destination("physics_second.log", LOGGER_LEVEL_ERROR, LOGGER_FORMAT_TEXT);
+        println("Added error-only destination to second logger");
+
+        physics_logger@ secondBase = secondLogger;
+        secondBase.log(LOGGER_LEVEL_ERROR, "SecondWorld", LOGGER_CATEGORY_WORLD, "Error from second logger");
+        println("Logged message with second logger");
+
+        physics_default_logger_destroy(secondLogger);
+        println("Destroyed second logger");
+    }
+
+    defaultLogger.add_file_destination("physics_temp1.log", LOGGER_LEVEL_WARNING, LOGGER_FORMAT_TEXT);
+    defaultLogger.add_file_destination("physics_temp2.html", LOGGER_LEVEL_INFORMATION, LOGGER_FORMAT_HTML);
+    println("Added temporary destinations");
+
+    baseLogger.log(LOGGER_LEVEL_WARNING, worldName, LOGGER_CATEGORY_WORLD, "Warning message for temp destinations");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, worldName, LOGGER_CATEGORY_BODY, "Info message for temp destinations");
+
+    defaultLogger.remove_all_destinations();
+    println("Removed all destinations");
+
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, worldName, LOGGER_CATEGORY_WORLD, "Message with no destinations");
+    println("Logged message with no destinations (silent)");
+
+    physics_logger@ finalLogger = physics_logger_get_current();
+    if (finalLogger !is null) {
+        println("Global logger is still set");
+
+        if (finalLogger is baseLogger) {
+            println("Global logger is the same as our base logger");
+        } else {
+            println("Global logger is different from our base logger");
+        }
+    } else {
+        println("Global logger was unexpectedly cleared");
+    }
+
+    defaultLogger.add_file_destination("physics_final.log", allLevels, LOGGER_FORMAT_TEXT);
+
+    baseLogger.log(LOGGER_LEVEL_ERROR, "TestWorld", LOGGER_CATEGORY_WORLD, "Individual ERROR level test");
+    baseLogger.log(LOGGER_LEVEL_WARNING, "TestWorld", LOGGER_CATEGORY_WORLD, "Individual WARNING level test");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, "TestWorld", LOGGER_CATEGORY_WORLD, "Individual INFORMATION level test");    
+
+    uint errorAndInfo = LOGGER_LEVEL_ERROR | LOGGER_LEVEL_INFORMATION;
+    defaultLogger.add_file_destination("physics_error_info.log", errorAndInfo, LOGGER_FORMAT_TEXT);
+
+    baseLogger.log(LOGGER_LEVEL_ERROR, "TestWorld", LOGGER_CATEGORY_COLLIDER, "Error that should appear in error+info log");
+    baseLogger.log(LOGGER_LEVEL_WARNING, "TestWorld", LOGGER_CATEGORY_COLLIDER, "Warning that should NOT appear in error+info log");
+    baseLogger.log(LOGGER_LEVEL_INFORMATION, "TestWorld", LOGGER_CATEGORY_COLLIDER, "Info that should appear in error+info log");
+
+    println("Tested log level combinations");
+
+    physics_logger_set_current(null);
+    physics_logger@ clearedLogger = physics_logger_get_current();
+    if (clearedLogger is null) {
+        println("Successfully cleared global logger");
+    } else {
+        println("Failed to clear global logger");
+    }
+
+    defaultLogger.remove_all_destinations();
+    println("Removed all destinations");
+
+    physics_default_logger_destroy(defaultLogger);
+}

--- a/test/quick/rp3d_meshes.nvgt
+++ b/test/quick/rp3d_meshes.nvgt
@@ -1,0 +1,304 @@
+void main() {
+    // Create a simple triangle
+    float[] triangleVertices = {
+        -1.0f, 0.0f, 0.0f,  // vertex 0: left
+         1.0f, 0.0f, 0.0f,  // vertex 1: right
+         0.0f, 1.0f, 0.0f   // vertex 2: top
+    };
+
+    uint[] triangleIndices = {
+        0, 1, 2  // single triangle
+    };
+
+    physics_triangle_data@ simpleTriangleData = physics_triangle_data(triangleVertices, triangleIndices);
+    physics_triangle_mesh@ simpleTriangleMesh = physics_triangle_mesh_create(simpleTriangleData);
+
+    println("Simple triangle mesh created:");
+    println("  Vertices: ", simpleTriangleMesh.nb_vertices);
+    println("  Triangles: ", simpleTriangleMesh.nb_triangles);
+
+    uint v1, v2, v3;
+    simpleTriangleMesh.get_triangle_vertices_indices(0, v1, v2, v3);
+    println("  Triangle 0 indices: " + v1 + " " + v2 + " " + v3);
+
+    vector vert0 = simpleTriangleMesh.get_vertex(0);
+    vector vert1 = simpleTriangleMesh.get_vertex(1);
+    vector vert2 = simpleTriangleMesh.get_vertex(2);
+    println("  Vertex 0: " + vert0.x + " " + vert0.y + " " + vert0.z);
+    println("  Vertex 1: " + vert1.x + " " + vert1.y + " " + vert1.z);
+    println("  Vertex 2: " + vert2.x + " " + vert2.y + " " + vert2.z);
+
+    vector tv1, tv2, tv3;
+    simpleTriangleMesh.get_triangle_vertices(0, tv1, tv2, tv3);
+    println("  Triangle vertices:");
+    println("    V1: " + tv1.x + " " + tv1.y + " " + tv1.z);
+    println("    V2: " + tv2.x + " " + tv2.y + " " + tv2.z);
+    println("    V3: " + tv3.x + " " + tv3.y + " " + tv3.z);
+
+    // Create a quad (2 triangles) with custom normals
+    float[] quadVertices = {
+        -1.0f, 0.0f, -1.0f,  // 0: back-left
+         1.0f, 0.0f, -1.0f,  // 1: back-right
+         1.0f, 0.0f,  1.0f,  // 2: front-right
+        -1.0f, 0.0f,  1.0f   // 3: front-left
+    };
+
+    // Custom normals (all pointing up)
+    float[] quadNormals = {
+        0.0f, 1.0f, 0.0f,    // normal for vertex 0
+        0.0f, 1.0f, 0.0f,    // normal for vertex 1
+        0.0f, 1.0f, 0.0f,    // normal for vertex 2
+        0.0f, 1.0f, 0.0f     // normal for vertex 3
+    };
+
+    uint[] quadIndices = {
+        0, 1, 2,    // first triangle
+        0, 2, 3     // second triangle
+    };
+
+    physics_triangle_data@ quadData = physics_triangle_data(quadVertices, quadNormals, quadIndices);
+    physics_triangle_mesh@ quadMesh = physics_triangle_mesh_create(quadData);
+
+    println("Quad mesh with normals created:");
+    println("  Vertices: ", quadMesh.nb_vertices);
+    println("  Triangles: ", quadMesh.nb_triangles);
+
+    vector norm0 = quadMesh.get_vertex_normal(0);
+    vector norm1 = quadMesh.get_vertex_normal(1);
+    println("  Vertex 0 normal: " + norm0.x + " " + norm0.y + " " + norm0.z);
+    println("  Vertex 1 normal: " + norm1.x + " " + norm1.y + " " + norm1.z);
+
+    vector tn1, tn2, tn3;
+    quadMesh.get_triangle_vertices_normals(0, tn1, tn2, tn3);
+    println("  Triangle 0 normals:");
+    println("    N1: " + tn1.x + " " + tn1.y + " " + tn1.z);
+    println("    N2: " + tn2.x + " " + tn2.y + " " + tn2.z);
+    println("    N3: " + tn3.x + " " + tn3.y + " " + tn3.z);
+
+    // Pyramid
+    float[] pyramidVertices = {
+        // Base vertices (square)
+        -2.0f, 0.0f, -2.0f,  // 0: back-left
+         2.0f, 0.0f, -2.0f,  // 1: back-right
+         2.0f, 0.0f,  2.0f,  // 2: front-right
+        -2.0f, 0.0f,  2.0f,  // 3: front-left
+        // Apex vertex
+         0.0f, 3.0f,  0.0f   // 4: top
+    };
+
+    uint[] pyramidIndices = {
+        // Base (2 triangles)
+        0, 2, 1,    // base triangle 1
+        0, 3, 2,    // base triangle 2
+        // Side faces
+        0, 1, 4,    // back face
+        1, 2, 4,    // right face
+        2, 3, 4,    // front face
+        3, 0, 4     // left face
+    };
+
+    physics_triangle_data@ pyramidData = physics_triangle_data(pyramidVertices, pyramidIndices);
+    physics_triangle_mesh@ pyramidMesh = physics_triangle_mesh_create(pyramidData);
+
+    println("Pyramid mesh created:");
+    println("  Vertices: ", pyramidMesh.nb_vertices);
+    println("  Triangles: ", pyramidMesh.nb_triangles);
+
+    aabb bounds = pyramidMesh.bounds;
+    println("  Bounds min: " + bounds.min.x + " " + bounds.min.y + " " + bounds.min.z);
+    println("  Bounds max: " + bounds.max.x + " " + bounds.max.y + " " + bounds.max.z);
+    println("  Bounds center: " + bounds.center.x + " " + bounds.center.y + " " + bounds.center.z);
+
+    println("  All triangle indices:");
+    for (uint i = 0; i < pyramidMesh.nb_triangles; i++) {
+        uint i1, i2, i3;
+        pyramidMesh.get_triangle_vertices_indices(i, i1, i2, i3);
+        println("    Triangle " + i + ": " + i1 + " " + i2 + " " + i3);
+    }
+
+    // Create concave mesh shapes from our triangle meshes
+    physics_concave_mesh_shape@ triangleShape = physics_concave_mesh_shape(simpleTriangleMesh);
+    physics_concave_mesh_shape@ quadShape = physics_concave_mesh_shape(quadMesh);
+    physics_concave_mesh_shape@ pyramidShape = physics_concave_mesh_shape(pyramidMesh);
+
+    println("Created concave mesh shapes:");
+
+    println("Triangle shape:");
+    println("  Vertices: ", triangleShape.nb_vertices);
+    println("  Triangles: ", triangleShape.nb_triangles);
+    println("  Volume: ", triangleShape.volume);
+
+    println("Quad shape:");
+    println("  Vertices: ", quadShape.nb_vertices);
+    println("  Triangles: ", quadShape.nb_triangles);
+    println("  Volume: ", quadShape.volume);
+
+    println("Pyramid shape:");
+    println("  Vertices: ", pyramidShape.nb_vertices);
+    println("  Triangles: ", pyramidShape.nb_triangles);
+
+    // This is a bit funky
+    // The rp3d docs say as follows:
+    // Compute and return the volume of the collision shape.
+    // Note that we approximate the volume of a concave shape with the volume of its AABB.
+    // So for us our AABB is 4 * 4 and since we're 3 units tall we need 4 * 4 * 3 = 48 units to enclose our pyramid
+    println("  Volume: ", pyramidShape.volume);
+
+    vector shapeVert = pyramidShape.get_vertex(4); // apex vertex
+    println("  Pyramid apex vertex: " + shapeVert.x + " " + shapeVert.y + " " + shapeVert.z);
+
+    uint si1, si2, si3;
+    pyramidShape.get_triangle_vertices_indices(0, si1, si2, si3);
+    println("  Pyramid triangle 0 indices: " + si1 + " " + si2 + " " + si3);
+
+    println("Scaling the pyramid");
+    vector scaling = vector(2.0f, 0.5f, 1.5f);
+    physics_concave_mesh_shape@ scaledPyramidShape = physics_concave_mesh_shape(pyramidMesh, scaling);
+
+    println("  Volume: ", scaledPyramidShape.volume);
+
+    vector scaledApex = scaledPyramidShape.get_vertex(4);
+    println("  Scaled apex vertex:"  + " " + scaledApex.x + " " + scaledApex.y + " " + scaledApex.z);
+
+    // Create a simple tetrahedron for convex mesh
+    float[] tetraVertices = {
+         1.0f,  1.0f,  1.0f,   // vertex 0
+        -1.0f, -1.0f,  1.0f,   // vertex 1
+        -1.0f,  1.0f, -1.0f,   // vertex 2
+         1.0f, -1.0f, -1.0f    // vertex 3
+    };
+
+    physics_vertex_data@ vertexData = physics_vertex_data(tetraVertices);
+    physics_convex_mesh@ convexMesh = physics_convex_mesh_create(vertexData);
+
+    if (convexMesh !is null) {
+        println("Convex mesh created:");
+        println("  Vertices: ", convexMesh.nb_vertices);
+        println("  Faces: ", convexMesh.nb_faces);
+        println("  Volume: ", convexMesh.volume);
+
+        aabb convexBounds = convexMesh.bounds;
+        println("  Bounds min: " + convexBounds.min.x + " " + convexBounds.min.y + " " + convexBounds.min.z);
+        println("  Bounds max: " + convexBounds.max.x + " " + convexBounds.max.y + " " + convexBounds.max.z);
+
+        vector centroid = convexMesh.centroid;
+        println("  Centroid: " + centroid.x + " " + centroid.y + " " + centroid.z);
+
+        physics_convex_mesh_shape@ convexShape = physics_convex_mesh_shape(convexMesh);
+        println("  Convex mesh shape volume: ", convexShape.volume);
+        println("  Convex mesh shape margin: ", convexShape.margin);
+
+        physics_convex_mesh_shape_destroy(convexShape);
+        physics_convex_mesh_destroy(convexMesh);
+    } else {
+        // Shouldn't happen!
+        println("Failed to create convex mesh (might need more vertices or better distribution)");
+    }
+
+    // Create a cube with explicit face definitions
+    float[] cubeVertices = {
+        // Bottom face
+        -1.0f, -1.0f, -1.0f,  // 0: back-left-bottom
+         1.0f, -1.0f, -1.0f,  // 1: back-right-bottom
+         1.0f, -1.0f,  1.0f,  // 2: front-right-bottom
+        -1.0f, -1.0f,  1.0f,  // 3: front-left-bottom
+        // Top face  
+        -1.0f,  1.0f, -1.0f,  // 4: back-left-top
+         1.0f,  1.0f, -1.0f,  // 5: back-right-top
+         1.0f,  1.0f,  1.0f,  // 6: front-right-top
+        -1.0f,  1.0f,  1.0f   // 7: front-left-top
+    };
+
+    // Define faces explicitly (each face is a quad)
+    array<array<uint>> cubeFaces = {
+        {0, 1, 2, 3},  // bottom face
+        {4, 7, 6, 5},  // top face
+        {0, 4, 5, 1},  // back face
+        {2, 6, 7, 3},  // front face
+        {0, 3, 7, 4},  // left face
+        {1, 5, 6, 2}   // right face
+    };
+
+    physics_polygon_data@ cubePolygonData = physics_polygon_data(cubeVertices, cubeFaces);
+    physics_convex_mesh@ explicitCubeMesh = physics_convex_mesh_create_from_polygon(cubePolygonData);
+
+    if (explicitCubeMesh !is null) {
+        println("Explicit cube mesh created:");
+        println("  Vertices: ", explicitCubeMesh.nb_vertices);
+        println("  Faces: ", explicitCubeMesh.nb_faces);
+
+        println("  Volume: ", explicitCubeMesh.volume);
+        vector explicitCentroid = explicitCubeMesh.centroid;
+        println("  Centroid: " + explicitCentroid.x + " " + explicitCentroid.y + " " + explicitCentroid.z);
+
+        // Compare with auto convex hull of same vertices
+        println("Comparing with auto convex hull:");
+        physics_vertex_data@ autoCubeData = physics_vertex_data(cubeVertices);
+        physics_convex_mesh@ autoCubeMesh = physics_convex_mesh_create(autoCubeData);
+
+        if (autoCubeMesh !is null) {
+            println("Auto cube mesh created:");
+            println("  Vertices: ", autoCubeMesh.nb_vertices);
+            println("  Faces: ", autoCubeMesh.nb_faces);
+            println("  Volume: ", autoCubeMesh.volume);
+
+            float volumeDiff = explicitCubeMesh.volume - autoCubeMesh.volume;
+            println("  Volume difference: " + volumeDiff + " (should be close to 0)");
+
+            physics_convex_mesh_destroy(autoCubeMesh);
+        } else {
+            // Shouldn't happen!
+            println("Failed to create autoCube mesh");
+        }
+
+        float[] mixedVertices = {
+            0.0f,  1.5f,  0.0f,   // 0: top vertex
+            -1.0f, -1.0f, -1.0f,   // 1: base corner 1
+            1.0f, -1.0f, -1.0f,   // 2: base corner 2  
+            1.0f, -1.0f,  1.0f,   // 3: base corner 3
+            -1.0f, -1.0f,  1.0f    // 4: base corner 4
+        };
+
+        array<array<uint>> mixedFaces = {
+            {0, 1, 2},        // triangle face (side)
+            {0, 2, 3},        // triangle face (side)
+            {0, 3, 4},        // triangle face (side)  
+            {0, 4, 1},        // triangle face (side)
+            {1, 2, 3, 4}      // quad face (base - 4 vertices)
+        };        
+
+        physics_polygon_data@ mixedPolygonData = physics_polygon_data(mixedVertices, mixedFaces);
+        physics_convex_mesh@ mixedMesh = physics_convex_mesh_create_from_polygon(mixedPolygonData);
+
+        if (mixedMesh !is null) {
+            println("Mixed face types mesh created:");
+            println("  Vertices: ", mixedMesh.nb_vertices);
+            println("  Faces: ", mixedMesh.nb_faces);
+            println("  Volume: ", mixedMesh.volume);
+
+            for (uint i = 0; i < mixedMesh.nb_faces; i++) {
+                vector faceNormal = mixedMesh.get_face_normal(i);
+                println("  Face " + i + " normal: " + faceNormal.x + " " + faceNormal.y + " " + faceNormal.z);
+            }
+
+            physics_convex_mesh_destroy(mixedMesh);
+        } else {
+            // Shouldn't happen!
+            println("Failed to create mixed face mesh");
+        }
+
+        physics_convex_mesh_destroy(explicitCubeMesh);
+    } else {
+        // Shouldn't happen!
+        println("Failed to create explicit cube mesh");
+    }
+
+    physics_concave_mesh_shape_destroy(triangleShape);
+    physics_concave_mesh_shape_destroy(quadShape);
+    physics_concave_mesh_shape_destroy(pyramidShape);
+    physics_concave_mesh_shape_destroy(scaledPyramidShape);
+
+    physics_triangle_mesh_destroy(simpleTriangleMesh);
+    physics_triangle_mesh_destroy(quadMesh);
+    physics_triangle_mesh_destroy(pyramidMesh);
+}

--- a/test/quick/rp3d_multi_object_sim.nvgt
+++ b/test/quick/rp3d_multi_object_sim.nvgt
@@ -10,7 +10,7 @@ void main() {
     physics_box_shape@ groundShape = physics_box_shape(vector(20, 0.5f, 20));
 
     // Create static ground
-    transform groundTransform(vector(0, -0.5f, 0), IDENTITY_QUATERNION);
+    physics_transform groundTransform(vector(0, -0.5f, 0), IDENTITY_QUATERNION);
     physics_rigid_body@ ground = world.create_rigid_body(groundTransform);
     ground.set_type(PHYSICS_BODY_STATIC);
     ground.add_collider(groundShape, IDENTITY_TRANSFORM);
@@ -20,7 +20,7 @@ void main() {
 
     for (int i = 0; i < 5; i++) {
         vector pos(i * 2.0f - 4.0f, 10 + i, 0);  // Spread them out
-        transform objTransform(pos, IDENTITY_QUATERNION);
+        physics_transform objTransform(pos, IDENTITY_QUATERNION);
 
         physics_rigid_body@ obj = world.create_rigid_body(objTransform);
         obj.set_type(PHYSICS_BODY_DYNAMIC);

--- a/test/quick/rp3d_raycast.nvgt
+++ b/test/quick/rp3d_raycast.nvgt
@@ -1,0 +1,314 @@
+// Global variables for demonstration
+physics_world@ world;
+physics_rigid_body@[] bodies;
+physics_collider@[] colliders;
+
+// Store shape references for cleanup  
+physics_sphere_shape@[] sphereShapes;
+physics_box_shape@[] boxShapes;
+physics_capsule_shape@[] capsuleShapes;
+
+// Hit counter for demonstrations
+int hitCount = 0;
+
+// Raycast callback for collecting all hits
+float collect_all_hits_callback(const raycast_info&in info) {
+    hitCount++;
+    println("=== HIT #" + hitCount + " DETECTED ===");
+    println("Hit Point: (" + info.world_point.x + ", " + info.world_point.y + ", " + info.world_point.z + ")");
+    println("Hit Normal: (" + info.world_normal.x + ", " + info.world_normal.y + ", " + info.world_normal.z + ")");
+    println("Hit Fraction: " + info.hit_fraction);
+    println("Triangle Index: " + info.triangle_index);
+    
+    if (info.body !is null) {
+        println("Hit Body Entity ID: " + info.body.entity.id);
+        vector pos = info.body.transform.position;
+        println("Body Transform: (" + pos.x + ", " + pos.y + ", " + pos.z + ")");
+    }
+
+    if (info.collider !is null) {
+        println("Hit Collider Entity ID: " + info.collider.entity.id);
+        println("Collider Shape Type: " + info.collider.collision_shape.type);
+        
+        // Determine shape type for better display
+        string shapeType = "Unknown";
+        if (info.collider.collision_shape.type == SHAPE_TYPE_SPHERE) {
+            shapeType = "Sphere";
+        } else if (info.collider.collision_shape.type == SHAPE_TYPE_CONVEX_POLYHEDRON) {
+            if (info.collider.collision_shape.name == SHAPE_BOX) {
+                shapeType = "Box";
+            } else if (info.collider.collision_shape.name == SHAPE_CAPSULE) {
+                shapeType = "Capsule";
+            }
+        }
+        println("Shape Name: " + shapeType);
+    }
+
+    println(); // Empty line for readability
+
+    // Return 1.0 to continue collecting all hits
+    return 1.0;
+}
+
+// Raycast callback that stops at first hit
+float stop_at_first_hit_callback(const raycast_info&in info) {
+    hitCount++;
+    println("=== FIRST HIT #" + hitCount + " - STOPPING ===");
+    println("Hit Point: (" + info.world_point.x + ", " + info.world_point.y + ", " + info.world_point.z + ")");
+    println("Hit Normal: (" + info.world_normal.x + ", " + info.world_normal.y + ", " + info.world_normal.z + ")");
+    println("Hit Fraction: " + info.hit_fraction);
+
+    if (info.body !is null) {
+        vector pos = info.body.transform.position;
+        println("Hit Body at: (" + pos.x + ", " + pos.y + ", " + pos.z + ")");
+    }
+
+    println(">>> RAYCAST STOPPED - No further hits will be detected <<<");
+    println();
+
+    // Return 0.0 to stop raycasting immediately
+    return 0.0;
+}
+
+// Raycast callback that clips ray at hit points
+float clip_ray_callback(const raycast_info&in info) {
+    hitCount++;
+    println("=== HIT #" + hitCount + " - CLIPPING RAY ===");
+    println("Hit Point: (" + info.world_point.x + ", " + info.world_point.y + ", " + info.world_point.z + ")");
+    println("Hit Normal: (" + info.world_normal.x + ", " + info.world_normal.y + ", " + info.world_normal.z + ")");
+    println("Original hit fraction: " + info.hit_fraction);
+
+    if (info.body !is null) {
+        vector pos = info.body.transform.position;
+        println("Hit Body at: (" + pos.x + ", " + pos.y + ", " + pos.z + ")");
+    }
+
+    println(">>> RAY CLIPPED - Effective ray length reduced to hit point <<<");
+    println();
+
+    // Return the hit fraction to clip the ray at this point
+    // This means the ray will be shortened to only go up to this hit point
+    return info.hit_fraction;
+}
+
+void setup_physics_world() {
+    physics_world_settings settings;
+    settings.world_name = "Raycast Demo World";
+    settings.gravity = vector(0, -9.81, 0);
+    settings.default_friction_coefficient = 0.3;
+    settings.default_bounciness = 0.5;
+
+    @world = physics_world(settings);
+
+    println("Created world: " + settings.world_name);
+    println("Gravity: (" + settings.gravity.x + ", " + settings.gravity.y + ", " + settings.gravity.z + ")");
+    println("Default friction: " + settings.default_friction_coefficient);
+    println("Default bounciness: " + settings.default_bounciness);
+    println();
+}
+
+void create_complex_scene() {
+    // Create a line of spheres
+    for (int i = 0; i < 3; i++) {
+        sphereShapes.insert_last(physics_sphere_shape(0.8));
+        vector pos(i * 3.0, 0, 0);
+        transform sphereTransform(pos, IDENTITY_QUATERNION);
+        bodies.insert_last(world.create_rigid_body(sphereTransform));
+        colliders.insert_last(bodies[bodies.length()-1].add_collider(sphereShapes[sphereShapes.length()-1], IDENTITY_TRANSFORM));
+        bodies[bodies.length()-1].type = PHYSICS_BODY_STATIC;
+
+        println("Created sphere " + (i+1) + " at: (" + pos.x + ", " + pos.y + ", " + pos.z + ") with radius 0.8");
+    }
+
+    // Create some boxes at different heights
+    for (int i = 0; i < 2; i++) {
+        boxShapes.insert_last(physics_box_shape(vector(0.7, 0.7, 0.7)));
+        vector pos(i * 4.0 + 1.5, 2.0, 0);
+        transform boxTransform(pos, IDENTITY_QUATERNION);
+        bodies.insert_last(world.create_rigid_body(boxTransform));
+        colliders.insert_last(bodies[bodies.length()-1].add_collider(boxShapes[boxShapes.length()-1], IDENTITY_TRANSFORM));
+        bodies[bodies.length()-1].type = PHYSICS_BODY_STATIC;
+        
+        println("Created box " + (i+1) + " at: (" + pos.x + ", " + pos.y + ", " + pos.z + ") with half-extents (0.7, 0.7, 0.7)");
+    }
+
+    // Create a capsule in the middle
+    capsuleShapes.insert_last(physics_capsule_shape(0.5, 2.0));
+    vector capsulePos(3.0, 0, 1.5);
+    transform capsuleTransform(capsulePos, IDENTITY_QUATERNION);
+    bodies.insert_last(world.create_rigid_body(capsuleTransform));
+    colliders.insert_last(bodies[bodies.length()-1].add_collider(capsuleShapes[capsuleShapes.length()-1], IDENTITY_TRANSFORM));
+    bodies[bodies.length()-1].type = PHYSICS_BODY_STATIC;
+
+    println("Created capsule at: (" + capsulePos.x + ", " + capsulePos.y + ", " + capsulePos.z + ") with radius 0.5 and height 2.0");
+
+    println("Total bodies created: " + bodies.length());
+    println();
+}
+
+void test_collect_all_hits() {
+    println("=== TEST 1: COLLECT ALL HITS CALLBACK ===");
+    println("This callback returns 1.0, so it will detect ALL objects along the ray path.");
+    println("Ray will pass through multiple spheres from left to right.");
+
+    ray testRay(vector(-2, 0, 0), vector(8, 0, 0));
+    println("Ray from: (" + testRay.point1.x + ", " + testRay.point1.y + ", " + testRay.point1.z + ")");
+    println("Ray to: (" + testRay.point2.x + ", " + testRay.point2.y + ", " + testRay.point2.z + ")");
+    println();
+    
+    hitCount = 0;
+    world.raycast(testRay, collect_all_hits_callback);
+    
+    println("RESULT: Detected " + hitCount + " total hits.");
+    println("=====================================");
+    println();
+}
+
+void test_stop_at_first_hit() {
+    println("=== TEST 2: STOP AT FIRST HIT CALLBACK ===");
+    println("This callback returns 0.0, so it will stop at the FIRST object hit.");
+    println("Ray will stop at the first sphere, ignoring objects behind it.");
+
+    ray testRay(vector(-2, 0, 0), vector(8, 0, 0));
+    println("Ray from: (" + testRay.point1.x + ", " + testRay.point1.y + ", " + testRay.point1.z + ")");
+    println("Ray to: (" + testRay.point2.x + ", " + testRay.point2.y + ", " + testRay.point2.z + ")");
+    println();
+
+    hitCount = 0;
+    world.raycast(testRay, stop_at_first_hit_callback);
+
+    println("RESULT: Detected " + hitCount + " hit(s) before stopping.");
+    println("==========================================");
+    println();
+}
+
+void test_clip_ray_callback() {
+    println("=== TEST 3: CLIP RAY CALLBACK ===");
+    println("This callback returns hit_fraction, which clips the ray at each hit point.");
+    println("Ray gets progressively shorter with each hit, but continues beyond each object.");
+
+    ray testRay(vector(-2, 0, 0), vector(8, 0, 0));
+    println("Ray from: (" + testRay.point1.x + ", " + testRay.point1.y + ", " + testRay.point1.z + ")");
+    println("Ray to: (" + testRay.point2.x + ", " + testRay.point2.y + ", " + testRay.point2.z + ")");
+    println("Original ray length: " + (testRay.point2 - testRay.point1).length());
+    println();
+
+    hitCount = 0;
+    world.raycast(testRay, clip_ray_callback);
+
+    println("RESULT: Ray was clipped " + hitCount + " time(s).");
+    println("===============================");
+    println();
+}
+
+void test_diagonal_ray() {
+    println("=== TEST 4: DIAGONAL RAY THROUGH SCENE ===");
+    println("Testing a diagonal ray that might hit objects at different heights.");
+
+    ray testRay(vector(-1, -1, -1), vector(7, 3, 2));
+    println("Ray from: (" + testRay.point1.x + ", " + testRay.point1.y + ", " + testRay.point1.z + ")");
+    println("Ray to: (" + testRay.point2.x + ", " + testRay.point2.y + ", " + testRay.point2.z + ")");
+
+    vector direction = testRay.point2 - testRay.point1;
+    direction.normalize();
+    println("Ray direction (normalized): (" + direction.x + ", " + direction.y + ", " + direction.z + ")");
+    println();
+
+    hitCount = 0;
+    world.raycast(testRay, collect_all_hits_callback);
+
+    println("RESULT: Diagonal ray hit " + hitCount + " object(s).");
+    println("=====================================");
+    println();
+}
+
+void test_ray_with_max_fraction() {
+    println("=== TEST 5: RAY WITH LIMITED MAX_FRACTION ===");
+    println("Testing ray behavior with max_fraction < 1.0 (shortened ray).");
+
+    ray testRay(vector(-2, 0, 0), vector(8, 0, 0), 0.3); // Only 30% of full ray length
+    vector effectiveEnd = testRay.point1 + (testRay.point2 - testRay.point1) * testRay.max_fraction;
+
+    println("Ray from: (" + testRay.point1.x + ", " + testRay.point1.y + ", " + testRay.point1.z + ")");
+    println("Ray to: (" + testRay.point2.x + ", " + testRay.point2.y + ", " + testRay.point2.z + ")");
+    println("Max fraction: " + testRay.max_fraction);
+    println("Effective end point: (" + effectiveEnd.x + ", " + effectiveEnd.y + ", " + effectiveEnd.z + ")");
+    println();
+
+    hitCount = 0;
+    world.raycast(testRay, collect_all_hits_callback);
+
+    println("RESULT: Limited ray hit " + hitCount + " object(s).");
+    println("=========================================");
+    println();
+}
+
+void test_individual_body_raycasts() {
+    println("=== TEST 6: INDIVIDUAL BODY RAYCASTS ===");
+    println("Testing direct raycast against specific bodies.");
+
+    ray testRay(vector(-1, 0, 0), vector(7, 3.5, 0));
+    raycast_info info;
+
+    for (uint i = 0; i < bodies.length(); i++) {
+        if (bodies[i] !is null) {
+            bool hit = bodies[i].raycast(testRay, info);
+            vector bodyPos = bodies[i].transform.position;
+
+            println("Body " + (i+1) + " at (" + bodyPos.x + ", " + bodyPos.y + ", " + bodyPos.z + "): " + (hit ? "HIT" : "MISS"));
+            if (hit) {
+                println("  Hit point: (" + info.world_point.x + ", " + info.world_point.y + ", " + info.world_point.z + ")");
+                println("  Hit fraction: " + info.hit_fraction);
+            }
+        }
+    }
+
+    println("===========================================");
+    println();
+}
+
+void cleanup() {
+    // Must do bodies first
+    // Doing shapes first gives segfaults because dangling references
+    if (world !is null) {
+        for (uint i = 0; i < bodies.length(); i++) {
+            if (bodies[i] !is null) {
+                world.destroy_rigid_body(bodies[i]);
+            }
+        }
+    }
+
+    for (uint i = 0; i < sphereShapes.length(); i++) {
+        if (sphereShapes[i] !is null) {
+            physics_sphere_shape_destroy(sphereShapes[i]);
+        }
+    }
+    for (uint i = 0; i < boxShapes.length(); i++) {
+        if (boxShapes[i] !is null) {
+            physics_box_shape_destroy(boxShapes[i]);
+        }
+    }
+    for (uint i = 0; i < capsuleShapes.length(); i++) {
+        if (capsuleShapes[i] !is null) {
+            physics_capsule_shape_destroy(capsuleShapes[i]);
+        }
+    }
+
+    if (world !is null) {
+        physics_world_destroy(world);
+    }
+}
+
+void main() {
+    setup_physics_world();
+    create_complex_scene();
+
+    test_collect_all_hits();
+    test_stop_at_first_hit();
+    test_clip_ray_callback();
+    test_diagonal_ray();
+    test_ray_with_max_fraction();
+    test_individual_body_raycasts();
+
+    cleanup();
+}

--- a/test/quick/rp3d_raycast.nvgt
+++ b/test/quick/rp3d_raycast.nvgt
@@ -112,7 +112,7 @@ void create_complex_scene() {
     for (int i = 0; i < 3; i++) {
         sphereShapes.insert_last(physics_sphere_shape(0.8));
         vector pos(i * 3.0, 0, 0);
-        transform sphereTransform(pos, IDENTITY_QUATERNION);
+        physics_transform sphereTransform(pos, IDENTITY_QUATERNION);
         bodies.insert_last(world.create_rigid_body(sphereTransform));
         colliders.insert_last(bodies[bodies.length()-1].add_collider(sphereShapes[sphereShapes.length()-1], IDENTITY_TRANSFORM));
         bodies[bodies.length()-1].type = PHYSICS_BODY_STATIC;
@@ -124,18 +124,18 @@ void create_complex_scene() {
     for (int i = 0; i < 2; i++) {
         boxShapes.insert_last(physics_box_shape(vector(0.7, 0.7, 0.7)));
         vector pos(i * 4.0 + 1.5, 2.0, 0);
-        transform boxTransform(pos, IDENTITY_QUATERNION);
+        physics_transform boxTransform(pos, IDENTITY_QUATERNION);
         bodies.insert_last(world.create_rigid_body(boxTransform));
         colliders.insert_last(bodies[bodies.length()-1].add_collider(boxShapes[boxShapes.length()-1], IDENTITY_TRANSFORM));
         bodies[bodies.length()-1].type = PHYSICS_BODY_STATIC;
-        
+
         println("Created box " + (i+1) + " at: (" + pos.x + ", " + pos.y + ", " + pos.z + ") with half-extents (0.7, 0.7, 0.7)");
     }
 
     // Create a capsule in the middle
     capsuleShapes.insert_last(physics_capsule_shape(0.5, 2.0));
     vector capsulePos(3.0, 0, 1.5);
-    transform capsuleTransform(capsulePos, IDENTITY_QUATERNION);
+    physics_transform capsuleTransform(capsulePos, IDENTITY_QUATERNION);
     bodies.insert_last(world.create_rigid_body(capsuleTransform));
     colliders.insert_last(bodies[bodies.length()-1].add_collider(capsuleShapes[capsuleShapes.length()-1], IDENTITY_TRANSFORM));
     bodies[bodies.length()-1].type = PHYSICS_BODY_STATIC;

--- a/test/quick/rp3d_user_data.nvgt
+++ b/test/quick/rp3d_user_data.nvgt
@@ -1,0 +1,128 @@
+void main() {
+    physics_world_settings settings;
+    settings.world_name = "Demo World";
+    physics_world@ world = physics_world(settings);
+
+    physics_transform transform;
+    transform.position = vector(0, 0, 0);
+    physics_rigid_body@ body = world.create_rigid_body(transform);
+
+    any@ stringData = "Hello Physics!";
+    body.set_user_data(stringData);
+
+    any@ retrievedString = body.get_user_data();
+    if (retrievedString !is null) {
+        string message;
+        retrievedString.retrieve(message);
+        println("Retrieved string: " + message);
+    } else {
+        println("Failed to retrieve string");
+    }
+
+    any@ numberData = 42.5f;
+    body.set_user_data(numberData);
+
+    any@ retrievedNumber = body.get_user_data();
+    if (retrievedNumber !is null) {
+        float value;
+        retrievedNumber.retrieve(value);
+        println("Retrieved number: " + value);
+    } else {
+        println("Failed to retrieve number");
+    }
+
+    dictionary@ dict = dictionary();
+    dict.set("name", "TestBody");
+    dict.set("health", 100);
+    dict.set("position", vector(1, 2, 3));
+
+    any@ dictData = @dict;
+    body.set_user_data(dictData);
+
+    any@ retrievedDict = body.get_user_data();
+    if (retrievedDict !is null) {
+        dictionary@ retrievedDictionary;
+        retrievedDict.retrieve(@retrievedDictionary);
+
+        if (retrievedDictionary !is null) {
+            string name;
+            int health;
+            vector pos;
+
+            retrievedDictionary.get("name", name);
+            retrievedDictionary.get("health", health);
+            retrievedDictionary.get("position", pos);
+
+            println("Retrieved dict - Name: " + name);
+            println("Retrieved dict - Health: " + health);
+            println("Retrieved dict - Position: " + pos.x + "," + pos.y + "," + pos.z);
+        }
+    } else {
+        println("Failed to retrieve dictionary");
+    }
+
+    body.set_user_data(null);
+    any@ clearedData = body.get_user_data();
+    println("Data after clearing: " + (clearedData is null ? "null" : "not null"));
+
+    physics_rigid_body@ body2 = world.create_rigid_body(transform);
+    physics_rigid_body@ body3 = world.create_rigid_body(transform);
+
+    any@ data1 = "Body1";
+    any@ data2 = "Body2"; 
+    any@ data3 = "Body3";
+
+    body.set_user_data(data1);
+    body2.set_user_data(data2);
+    body3.set_user_data(data3);
+
+    for (int i = 0; i < 3; i++) {
+        physics_rigid_body@ currentBody;
+        string bodyName;
+
+        if (i == 0) {
+            @currentBody = body;
+            bodyName = "First";
+        } else if (i == 1) {
+            @currentBody = body2;
+            bodyName = "Second";
+        } else {
+            @currentBody = body3;
+            bodyName = "Third";
+        }
+
+        any@ data = currentBody.get_user_data();
+        if (data !is null) {
+            string value;
+            data.retrieve(value);
+            println(bodyName + " body data: " + value);
+        }
+    }
+
+    physics_body@ genericBody = body; // Upcast
+    any@ dataFromGeneric = genericBody.get_user_data();
+    if (dataFromGeneric !is null) {
+        string value;
+        dataFromGeneric.retrieve(value);
+        println("Data accessed via generic body: " + value);
+    } else {
+        println("Failed to access data from generic body");
+    }
+
+    any@ intData = 123;
+    body.set_user_data(intData);
+
+    any@ retrievedInt = body.get_user_data();
+    if (retrievedInt !is null) {
+        int value;
+        retrievedInt.retrieve(value);
+        println("Retrieved integer: " + value);
+    } else {
+        println("Failed to retrieve integer");
+    }
+
+    world.destroy_rigid_body(body);
+    world.destroy_rigid_body(body2);
+    world.destroy_rigid_body(body3);
+    physics_world_destroy(world);
+}


### PR DESCRIPTION
Expands the current physics wrapper. In particular:
- Fixed world settings not being copiable.
- Fixed add collider not being registered correctly and creating a temporary shape in the background
- Added generic physics shape destroy function for ease of use
- Added support for meshes
- Added a raycasting example
- Added bare bones logging. It is currently impossible to create a custom angelscript physics logger; I think the default one should satisfy the majority of user needs. If there is a demand for it, we can look into exposing a proper interface to do so.
- Added creation of height fields.
- Added support for user data on bodies.
- When adding user data, ensured that we hold a reference to the object and that body destruction releases said reference.
- Added some niceties like being able to upcast rigid body to the base abstract body class.
- Renamed transform to physics_transform to follow the naming standard and reduce chance of name conflicts.
- Added demos for all of the above features. Demos have been verified to run and compile, and their output made mathematical sense.


I would say majority of the API has been completed. One final thing left to consider are joints, but since few people will use those, we can somewhat delay on that. Also some consideration should be given to the delicate dance necessary to correctly destroy objects. That is the most faulty part right now and will give segfaults if done out of order.


People can use this, though they should still expect some kinks when doing so and for API to change as we figure out a safer primitive as opposed to raw pointers for physics objects.