### PR TITLE
Several improvements and fixes to tone_synth

### DIFF
--- a/dep/tonar.c
+++ b/dep/tonar.c
@@ -91,6 +91,32 @@ gen->cursor+=samples;
 if(gen->cursor>gen->length) gen->length=gen->cursor;
 return 1;
 }
+int el_tonar_get_length(el_tonar* gen)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+double t=((double) gen->length)/(gen->sample_rate*gen->channels)*1000;
+return t;
+}
+int el_tonar_get_position(el_tonar* gen)
+{
+if(!elz_tonar_is_init(gen)) return 0;
+double t=((double) gen->cursor)/(gen->sample_rate*gen->channels)*1000;
+return t;
+}
+int el_tonar_seek(el_tonar* gen, int position)
+{
+if(position<0) return 0;
+int l=el_tonar_get_length(gen);
+if(position>=l) return 0;
+int frame=elz_tonar_ms_to_frames(gen, position);
+int sample=frame*gen->channels;
+gen->cursor=sample;
+return 1;
+}
+int el_tonar_rewind(el_tonar* gen, int amount)
+{
+return el_tonar_seek(gen, el_tonar_get_position(gen)-amount);
+}
 int el_tonar_output_buffer_size(el_tonar* gen)
 {
 if(elz_tonar_is_silent(gen)) return 0;
@@ -183,7 +209,7 @@ if(samples<gen->size) return 1;
 samples*=2;
 double* data=realloc(gen->data, samples*sizeof(double));
 if(!data) return 0;
-memset(data+gen->size, 0, samples-gen->size);
+memset(data+gen->size, 0, (samples-gen->size)*sizeof(double));
 gen->data=data;
 gen->size=samples;
 return 1;
@@ -378,7 +404,7 @@ return sample*fade_factor;
 int elz_tonar_adjust_length(el_tonar* gen, int samples)
 {
 if(!elz_tonar_is_init(gen)) return 0;
-int length=gen->cursor;
+int length=gen->cursor+samples;
 if(length>gen->length) gen->length=length;
 return 1;
 }

--- a/dep/tonar.h
+++ b/dep/tonar.h
@@ -36,6 +36,10 @@ int el_tonar_set_pan(el_tonar* gen, double pan);
 int el_tonar_set_edge_fades(el_tonar* gen, int start, int end);
 int el_tonar_freq(el_tonar* gen, double freq, int ms);
 int el_tonar_rest(el_tonar* gen, int ms);
+int el_tonar_get_length(el_tonar* gen);
+int el_tonar_get_position(el_tonar* gen);
+int el_tonar_seek(el_tonar* gen, int position);
+int el_tonar_rewind(el_tonar* gen, int amount);
 int el_tonar_output_buffer_size(el_tonar* gen);
 int el_tonar_output_buffer(el_tonar* gen, char* buffer, int size);
 int el_tonar_output_file(el_tonar* gen, char* fn);
@@ -85,5 +89,6 @@ double elz_tonar_apply_fade_in(int frame, int fade_in_frames, double sample);
 double elz_tonar_apply_fade_out(int frame, int total_frames, int fade_out_frames, double sample);
 int elz_tonar_adjust_length(el_tonar* gen, int samples);
 double elz_tonar_poly_blep(double t, double dt);
-
+int elz_tonar_sample_to_ms(el_tonar* gen, int sample);
+int elz_tonar_ms_to_sample(el_tonar* gen, int ms);
 #endif

--- a/src/tonesynth.cpp
+++ b/src/tonesynth.cpp
@@ -99,6 +99,7 @@ init_sound();
 	bool loaded = s->load_pcm(buffer, static_cast<unsigned int>(size), ma_format_s16, gen->sample_rate, gen->channels);
 	delete[] buffer;
 	if (!loaded) {
+		s->release(); // Sound object is not passed to the script if load fails, delete it.
 		return nullptr;
 	}
 	return s;

--- a/src/tonesynth.cpp
+++ b/src/tonesynth.cpp
@@ -36,11 +36,17 @@ void tone_synth::Release() {
 		delete this;
 	}
 }
-void tone_synth::set_waveform(int type) {
-	el_tonar_set_waveform(gen, type);
+void tone_synth::reset() {
+	el_tonar_reset(gen);
 }
+void tone_synth::set_waveform(int type) {
+	int real_type = bgt_to_tonar_waveform(type);
+	if (real_type < 0) return;
+	el_tonar_set_waveform(gen, real_type);
+}
+
 int tone_synth::get_waveform() {
-	return gen->waveform;
+	return bgt_to_tonar_waveform(gen->waveform);
 }
 void tone_synth::set_volume(double db) {
 	el_tonar_set_volume(gen, db);
@@ -57,13 +63,26 @@ double tone_synth::get_pan() {
 bool tone_synth::set_edge_fades(int start, int end) {
 	return el_tonar_set_edge_fades(gen, start, end)? true: false;
 }
-bool tone_synth::freq(double freq, int ms) {
+bool tone_synth::freq_ms(double freq, int ms) {
 	return el_tonar_freq(gen, freq, ms)? true: false;
 }
-bool tone_synth::rest(int ms) {
+bool tone_synth::rest_ms(int ms) {
 	return el_tonar_rest(gen, ms)? true: false;
 }
+int tone_synth::get_length_ms() {
+	return el_tonar_get_length(gen);
+}
+int tone_synth::get_position_ms() {
+	return el_tonar_get_position(gen);
+}
+bool tone_synth::seek_ms(int position) {
+	return el_tonar_seek(gen, position)? true: false;
+}
+bool tone_synth::rewind_ms(int amount) {
+	return el_tonar_rewind(gen, amount)? true: false;
+}
 sound* tone_synth::generate_sound() {
+init_sound();
 	int size = el_tonar_output_buffer_size(gen);
 	if (size <= 0) return nullptr;
 	char* buffer = new char[size];
@@ -72,7 +91,7 @@ sound* tone_synth::generate_sound() {
 		delete[] buffer;
 		return nullptr;
 	}
-	sound *s = new_global_sound();
+	sound *s = g_audio_engine->new_sound();
 	if (!s) {
 		delete[] buffer;
 		return nullptr;
@@ -80,13 +99,19 @@ sound* tone_synth::generate_sound() {
 	bool loaded = s->load_pcm(buffer, static_cast<unsigned int>(size), ma_format_s16, gen->sample_rate, gen->channels);
 	delete[] buffer;
 	if (!loaded) {
-		s->release();
 		return nullptr;
 	}
 	return s;
 }
 bool tone_synth::generate_file(const std::string& filename) {
 	return el_tonar_output_file(gen, const_cast<char*> (filename.c_str()))? true: false;
+}
+int tone_synth::bgt_to_tonar_waveform(int type) {
+	if (type == 1) return 3;
+	if (type == 2) return 2;
+	if (type == 3) return 0;
+	if (type == 4) return 1;
+	return -1;
 }
 tone_synth *script_tone_synth_factory() {
 	return new tone_synth();
@@ -96,15 +121,20 @@ void RegisterScriptTonesynth(asIScriptEngine* engine) {
 	engine->RegisterObjectBehaviour("tone_synth", asBEHAVE_FACTORY, "tone_synth@ f()", asFUNCTION(script_tone_synth_factory), asCALL_CDECL);
 	engine->RegisterObjectBehaviour("tone_synth", asBEHAVE_ADDREF, "void f()", asMETHOD(tone_synth, AddRef), asCALL_THISCALL);
 	engine->RegisterObjectBehaviour("tone_synth", asBEHAVE_RELEASE, "void f()", asMETHOD(tone_synth, Release), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "void reset()", asMETHOD(tone_synth, reset), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "void set_waveform_type(int type) property", asMETHOD(tone_synth, set_waveform), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "int get_waveform_type() const property", asMETHOD(tone_synth, get_waveform), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "void set_volume(double value) property", asMETHOD(tone_synth, set_volume), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "double get_volume() const property", asMETHOD(tone_synth, get_volume), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "void set_pan(double value) property", asMETHOD(tone_synth, set_pan), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "double get_pan() const property", asMETHOD(tone_synth, get_pan), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "int get_position_ms() const property", asMETHOD(tone_synth, get_position_ms), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "int get_length_ms() const property", asMETHOD(tone_synth, get_length_ms), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool seek_ms(int position)", asMETHOD(tone_synth, seek_ms), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool rewind_ms(int amount)", asMETHOD(tone_synth, rewind_ms), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "bool set_edge_fades(int start, int end)", asMETHOD(tone_synth, set_edge_fades), asCALL_THISCALL);
-	engine->RegisterObjectMethod("tone_synth", "bool freq(double freq, int ms)", asMETHOD(tone_synth, freq), asCALL_THISCALL);
-	engine->RegisterObjectMethod("tone_synth", "bool rest(int ms)", asMETHOD(tone_synth, rest), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool freq_ms(double freq, int ms)", asMETHOD(tone_synth, freq_ms), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool rest_ms(int ms)", asMETHOD(tone_synth, rest_ms), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "sound@ write_wave_sound()", asMETHOD(tone_synth, generate_sound), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "bool write_wave_file(const string &in filename)", asMETHOD(tone_synth, generate_file), asCALL_THISCALL);
 }

--- a/src/tonesynth.h
+++ b/src/tonesynth.h
@@ -32,6 +32,7 @@ public:
 	void AddRef();
 	void Release();
 
+	void reset();
 	void set_waveform(int type);
 	int get_waveform();
 	void set_volume(double db);
@@ -39,12 +40,19 @@ public:
 	void set_pan(double pan);
 	double get_pan();
 	bool set_edge_fades(int start, int end);
-	bool freq(double freq, int ms);
-	bool rest(int ms);
+	bool freq_ms(double freq, int ms);
+	bool rest_ms(int ms);
+	int get_length_ms();
+	int get_position_ms();
+	bool seek_ms(int position);
+	bool rewind_ms(int amount);
+
 	sound* generate_sound();
 	bool generate_file(const std::string& filename);
 
 private:
+	int bgt_to_tonar_waveform(int type);
+
 	int refCount = 1;
 	el_tonar* gen = nullptr;
 };


### PR DESCRIPTION
Since tone_synth has now been merged straight into main, I felt a real sense of urgency to try and remove as much flakiness from it as I know how, and that I have found to date.

* Update Tonar to fix some memory initialisation/allocation bugs
* Started work on improving BGT compatibility
* Add cursor facilities (length/position/seek etc)

Also changed the tone_synth class to use g_audio_engine->new_sound() similar to how TTS does it, replacing my previous code that directly called new_global_sound() - I have no idea what should be used when and how, the audio code I'm finding very confusing. Really hope I'm doing everything right in that area.

Still haven't added tempo/note-based manipulation yet, might find time to do that later unless someone beats me to it.
