### PR TITLE
[fix]string::slice: negative start returning empty string

### DIFF
--- a/ASAddon/src/scriptstdstring_utils.cpp
+++ b/ASAddon/src/scriptstdstring_utils.cpp
@@ -148,7 +148,7 @@ static string StringSlice(int start, int end, const string &str)
 	asUINT size = str.size();
 	if (start < 0)
 		start = size + start;
-	if (end < 0)
+	if (end <= 0)
 		end = size + end;
 	if (end >= size)
 		end = size;


### PR DESCRIPTION
Some time after June 11th, providing string::slice with a negative start and end of 0 results in it returning an empty string.
E.g., with the current release (62c73c7), slicing an 8-char string like:
````
void main() {
 alert("test.ogg".slice(-4, 0), "");
}
````
shows an empty string on Windows 10 22h2, as opposed to ".ogggggg" as is the expected and prior behavior.
I believe the problem to be line 151 in scriptstdstring_utils.cpp:
````
	if (end < 0)
		end = size + end;
// end is 0, not less than 0, so it stays 0
````
Because then if end is 0,
````
	if (start < 0)
		start = size + start;
// in our example, 8+(-4)=8-4=4
	int count = end - start;
// 0-4=-4
````
fix:
````
	if (end <= 0)
		end = size + end;
// end is equal or less than 0, so end becomes 8+0=8, aka. the end of the string
````
Because then if end is 8,
````
	if (start < 0)
		start = size + start;
// just like before, 8+(-4)=8-4=4
	int count = end - start;
// unlike before, now that end is 8, we get 8-4=4, which is what we want
````
Result: ".ogg".
I don't know if this is on purpose, I couldn't track down the commit that changed the behavior.