### PR TITLE
Section_istream relative seek fix

### DIFF
--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -497,7 +497,7 @@ std::streampos section_istreambuf::seekoff(std::streamoff off, std::ios_base::se
 			// Istream uses 0 cur to implement tell, so just report the current position without moving anything.
 			if (off == 0)
 				return source->tellg() - (std::streampos) start - (std::streampos) in_avail();
-			return seekpos(source->tellg() - std::streampos(start - in_avail() + off));
+			return seekpos(source->tellg() - (std::streampos)start - (std::streampos)in_avail() + off);
 	}
 	return -1; // Can't get here.
 }


### PR DESCRIPTION
Addresses https://github.com/samtupy/nvgt/issues/242

The fix is on line 500 of Pack.cpp:
```
			return seekpos(source->tellg() - (std::streampos)start - (std::streampos)in_avail() + off);
```

 @samtupy, I believe this is the same line that you and I have had to go back and forth on a few times now, so please let me know if this builds on non-Windows as I'm not currently set up to test that.

What was happening was that instead of seeking to source->tellg() - start - in_avail + off, it was seeking to source->tellg() - (start - in_avail()) + off which of course sends it to a negative offset. The end result was that it was reading garbage data outside the sandbox.
