### PR TITLE
Further BGT compatibility in tone_synth

### DIFF
--- a/dep/tonar.h
+++ b/dep/tonar.h
@@ -7,9 +7,6 @@
 #include <math.h>
 #include <ctype.h>
 
-#define elz_tonar_begin 0xACC737A3
-#define elz_tonar_end 0xDC76AAED
-
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
@@ -17,6 +14,12 @@
 #ifndef M_PI_4
 #define M_PI_4 0.78539816339744830962
 #endif
+
+#define el_tonar_min_db -100
+#define el_tonar_max_db 0
+
+#define el_tonar_default_fade_start 8
+#define el_tonar_default_fade_end 12
 
 typedef enum
 {
@@ -42,6 +45,8 @@ int el_tonar_set_waveform(el_tonar* gen, int type);
 int el_tonar_get_waveform(el_tonar* gen);
 int el_tonar_set_volume(el_tonar* gen, double db);
 double el_tonar_get_volume(el_tonar* gen);
+int el_tonar_set_allow_silence(el_tonar* gen, int silence);
+int el_tonar_get_allow_silence(el_tonar* gen);
 int el_tonar_set_pan(el_tonar* gen, double pan);
 double el_tonar_get_pan(el_tonar* gen);
 int el_tonar_set_edge_fades(el_tonar* gen, int start, int end);
@@ -73,6 +78,9 @@ int el_tonar_output_buffer_size(el_tonar* gen);
 int el_tonar_output_buffer(el_tonar* gen, char* buffer, int size);
 int el_tonar_output_file(el_tonar* gen, char* fn);
 
+#define elz_tonar_begin 0xACC737A3
+#define elz_tonar_end 0xDC76AAED
+
 struct elz_tonar
 {
 int begin;
@@ -92,6 +100,7 @@ double volume;
 int fade_start;
 int fade_end;
 int waveform;
+int output_silence;
 int end;
 };
 
@@ -99,6 +108,7 @@ int elz_tonar_cleanup(el_tonar* gen);
 int elz_tonar_is_init(el_tonar* gen);
 int elz_tonar_is_empty(el_tonar* gen);
 int elz_tonar_is_silent(el_tonar* gen);
+int elz_tonar_can_output(el_tonar* gen);
 int elz_tonar_sequence(el_tonar* gen, double freq, double bend_amount, int length, int bend_start, int bend_length);
 int elz_tonar_ms_to_frames(el_tonar* gen, int ms);
 int elz_tonar_manage_buffer(el_tonar* gen, int samples);

--- a/src/tonesynth.cpp
+++ b/src/tonesynth.cpp
@@ -37,6 +37,8 @@ void tone_synth::Release() {
 }
 void tone_synth::reset() {
 	el_tonar_reset(gen);
+	el_tonar_set_waveform(gen, 3);
+	el_tonar_set_allow_silence(gen, 1);
 }
 void tone_synth::set_waveform(int type) {
 	int real_type = bgt_to_tonar_waveform(type);
@@ -57,6 +59,12 @@ void tone_synth::set_pan(double pan) {
 }
 double tone_synth::get_pan() {
 	return el_tonar_get_pan(gen);
+}
+void tone_synth::set_allow_silence(bool silence) {
+	el_tonar_set_allow_silence(gen, (silence? 1: 0));
+}
+bool tone_synth::get_allow_silence() {
+	return (el_tonar_get_allow_silence(gen)? true: false);
 }
 bool tone_synth::set_edge_fades(int start, int end) {
 	return el_tonar_set_edge_fades(gen, start, end)? true: false;
@@ -177,6 +185,8 @@ void RegisterScriptTonesynth(asIScriptEngine* engine) {
 	engine->RegisterObjectMethod("tone_synth", "void reset()", asMETHOD(tone_synth, reset), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "void set_waveform_type(int type) property", asMETHOD(tone_synth, set_waveform), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "int get_waveform_type() const property", asMETHOD(tone_synth, get_waveform), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "void set_allow_silent_output(bool silence) property", asMETHOD(tone_synth, set_allow_silence), asCALL_THISCALL);
+	engine->RegisterObjectMethod("tone_synth", "bool get_allow_silent_output() const property", asMETHOD(tone_synth, get_allow_silence), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "void set_volume(double value) property", asMETHOD(tone_synth, set_volume), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "double get_volume() const property", asMETHOD(tone_synth, get_volume), asCALL_THISCALL);
 	engine->RegisterObjectMethod("tone_synth", "void set_pan(double value) property", asMETHOD(tone_synth, set_pan), asCALL_THISCALL);

--- a/src/tonesynth.h
+++ b/src/tonesynth.h
@@ -38,6 +38,8 @@ public:
 	double get_volume();
 	void set_pan(double pan);
 	double get_pan();
+	void set_allow_silence(bool silence);
+	bool get_allow_silence();
 	bool set_edge_fades(int start, int end);
 	void set_tempo(double tempo);
 	double get_tempo();


### PR DESCRIPTION
No output would be generated if the synth detected that it would be silent. This is now configurable via the allow_silent_output property.

By default tone_synth is now reset to BGT defaults:
* Initial waveform: Saw
* Allow silence: true
* Start/end fade times: 8, 12.