### PR TITLE
Fix bug in string_right

### DIFF
--- a/release/include/bgt_compat.nvgt
+++ b/release/include/bgt_compat.nvgt
@@ -26,7 +26,7 @@ string string_left(const string& in str, uint count) {
 string string_right(const string& in str, uint count) {
 	if (str == "") return str;
 	if (count >= str.length()) return str;
-	return str.slice(str.length() - count, 0);
+	return str.slice(str.length() - count, str.length());
 }
 string string_trim_left(const string& in str, uint count) {
 	if (str == "") return str;


### PR DESCRIPTION
Setting slice end to 0 returns an empty string, fixed by explicitly setting the end index.

I recall an issue or PR raised about a bug in slice not so long back, not sure if this has anything to do with it or whether it got resolved.
