### PR TITLE
Update key handling and rename sound test files

### DIFF
--- a/test/quick/get_key_name.nvgt
+++ b/test/quick/get_key_name.nvgt
@@ -14,7 +14,7 @@ void main() {
 }
 
 void announce_keys() {
-	key_code[]@ key_codes = keys_pressed();
+	int[]@ key_codes = keys_pressed();
 	if (key_codes.empty())
 		return;
 

--- a/test/quick/legacy_slide_sound.nvgt
+++ b/test/quick/legacy_slide_sound.nvgt
@@ -2,6 +2,9 @@
 // Copyright (C) 2022-2024 Sam Tupy
 // License: zlib (see license.md in the root of the NVGT distribution)
 
+#pragma namespace sound upcoming
+#pragma plugin legacy_sound
+//using namespace legacy;
 void main() {
 	sound s;
 	s.load("C:\\Windows\\media\\ding.wav");

--- a/test/quick/legacy_sound_callbacks.nvgt
+++ b/test/quick/legacy_sound_callbacks.nvgt
@@ -2,6 +2,9 @@
 // Copyright (C) 2022-2024 Sam Tupy
 // License: zlib (see license.md in the root of the NVGT distribution)
 
+#pragma namespace sound upcoming
+#pragma plugin legacy_sound
+//using namespace legacy;
 class soundstream {
 	string filename;
 	file f;


### PR DESCRIPTION
Changed key_codes type from key_code[]@ to int[]@ in get_key_name.nvgt for compatibility. Renamed slide_sound.nvgt and sound_callbacks.nvgt to legacy_slide_sound.nvgt and legacy_sound_callbacks.nvgt, adding legacy sound plugin pragmas for legacy namespace support.