### PR TITLE
Timezone implementation

### DIFF
--- a/src/timestuff.h
+++ b/src/timestuff.h
@@ -24,6 +24,12 @@ class CScriptArray;
 uint64_t ticks(bool secure = true);
 uint64_t microticks(bool secure = true);
 
+bool set_timezone(const std::string& timezone_name);
+void reset_timezone();
+std::string get_current_timezone_name();
+int get_current_timezone_offset();
+CScriptArray* list_available_timezones();
+
 class timer_queue;
 class timer_queue_item : public TimerEventInterface {
 public:

--- a/test/quick/timezone.nvgt
+++ b/test/quick/timezone.nvgt
@@ -1,0 +1,41 @@
+// NonVisual Gaming Toolkit (NVGT)
+// Copyright (C) 2022-2024 Sam Tupy
+// License: zlib (see license.md in the root of the NVGT distribution)
+
+void main() {
+	
+	// Display current system timezone and time
+	string current_tz = get_current_timezone_name();
+	alert("Current System Timezone", "Timezone: " + current_tz + "\nCurrent time: " + TIME_HOUR + ":" + TIME_MINUTE + ":" + TIME_SECOND);
+	
+	// Set timezone to New York
+	if (set_timezone("America/New_York")) {
+		string ny_tz = get_current_timezone_name();
+		alert("New York Timezone", "Timezone: " + ny_tz + "\nTime: " + TIME_HOUR + ":" + TIME_MINUTE + ":" + TIME_SECOND);
+	} else {
+		alert("Error", "Failed to set New York timezone");
+	}
+	
+	// Set timezone to Tokyo
+	if (set_timezone("Asia/Tokyo")) {
+		string tokyo_tz = get_current_timezone_name();
+		alert("Tokyo Timezone", "Timezone: " + tokyo_tz + "\nTime: " + TIME_HOUR + ":" + TIME_MINUTE + ":" + TIME_SECOND);
+	} else {
+		alert("Error", "Failed to set Tokyo timezone");
+	}
+	
+	calendar cal;
+	cal.set(2024, 12, 25, 14, 30, 45); // Set Christmas 2024, 2:30:45 PM
+	alert("Calendar with Set Time", "Calendar maintains its time:\n" + cal.hour + ":" + cal.minute + ":" + cal.second + "\nDate: " + cal.day + "/" + cal.month + "/" + cal.year);
+	
+	cal.reset();
+	alert("Calendar After Reset", "Calendar after reset (current timezone):\n" + cal.hour + ":" + cal.minute + ":" + cal.second + "\nDate: " + cal.day + "/" + cal.month + "/" + cal.year);
+	
+	string[] timezones = list_available_timezones();
+	string timezone_list = "";
+	for (uint i = 0; i < timezones.length() && i < 10; i++) {
+		timezone_list += timezones[i] + "\n";
+	}
+	timezone_list += "... and " + (timezones.length() - 10) + " more";
+	alert("Available Timezones (" + timezones.length() + " total)", timezone_list);
+}


### PR DESCRIPTION
This implementation allows developers to set different timezones at runtime.
Functions:
set_timezone(string timezone_id) - Sets the active timezone using standard timezone identifiers (e.g., "America/New_York", "Asia/Tokyo")
reset_timezone() - Resets to system default timezone
get_current_timezone_name() - Returns the name of the currently active timezone
get_current_timezone_offset() - Gets the UTC offset in seconds for the current timezone
list_available_timezones() - Returns an array of all supported timezone identifiers

The system supports 200+ official timezone identifiers following PHP timezone standards
Calendar objects automatically respect the active timezone when created
A test of how to use the new implementation was added in test/quick/timezone.nvgt

**Note:** I've tested this and it seems to work well, but I'm still quite new to C++. Please test it more thoroughly before approving.