### PR TITLE
Make memory_buffer a Reference type

### DIFF
--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -11,7 +11,6 @@
 */
 
 #define NOMINMAX
-#include <cstdint> // uint64_t
 #include <string>
 #include <algorithm>
 #include <vector>
@@ -372,7 +371,7 @@ bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
 }
 void script_memory_buffer::angelscript_register(asIScriptEngine* engine) {
 	engine->RegisterObjectType("memory_buffer<class T>", sizeof(script_memory_buffer), asOBJ_VALUE | asOBJ_TEMPLATE | asGetTypeTraits<script_memory_buffer>());
-	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_CONSTRUCT, "void f(int&in subtype, uint64 ptr, uint64 size)", asFUNCTION(make), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_CONSTRUCT, "void f(int&in subtype, uint64 ptr = 0, uint64 size = 0)", asFUNCTION(make), asCALL_CDECL_OBJFIRST);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_CONSTRUCT, "void f(int&in subtype, const memory_buffer<T>&in other)", asFUNCTION(copy), asCALL_CDECL_OBJFIRST);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_TEMPLATE_CALLBACK, "bool f(int&in subtype, bool&out no_gc)", asFUNCTION(verify), asCALL_CDECL);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_DESTRUCT, "void f()", asFUNCTION(destroy), asCALL_CDECL_OBJFIRST);

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -370,7 +370,7 @@ bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
 	return no_gc = true;
 }
 void script_memory_buffer::angelscript_register(asIScriptEngine* engine) {
-	engine->RegisterObjectType("memory_buffer<class T>", 0, asOBJ_REF | asOBJ_TEMPLATE);
+	engine->RegisterObjectType("memory_buffer<class T>", sizeof(script_memory_buffer), asOBJ_REF | asOBJ_TEMPLATE | asGetTypeTraits<script_memory_buffer>());
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_FACTORY, "memory_buffer<T>@ f(int&in subtype, uint64 ptr, uint64 size)", asFUNCTION(make), asCALL_CDECL);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_FACTORY, "memory_buffer<T>@ f(int&in subtype, const memory_buffer<T>&in other)", asFUNCTION(copy), asCALL_CDECL);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_ADDREF, "void f()", asMETHOD(script_memory_buffer, AddRef), asCALL_THISCALL);

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -363,7 +363,7 @@ script_memory_buffer& script_memory_buffer::from_array(CScriptArray* array) {
 	return *this;
 }
 int script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
-script_memory_buffer* script_memory_buffer::make(asITypeInfo* subtype, uint64_t ptr, uint64_t size) { return new script_memory_buffer(subtype, ptr, size); }
+void script_memory_buffer::make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, int size) { new(mem) script_memory_buffer(subtype, ptr, size); }
 void script_memory_buffer::copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other) { new(mem) script_memory_buffer(other); }
 bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
 	if (subtype->GetSubTypeId() & asTYPEID_MASK_OBJECT ) return false;

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -363,6 +363,12 @@ script_memory_buffer& script_memory_buffer::from_array(CScriptArray* array) {
 	return *this;
 }
 int script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
+bool script_memory_buffer::update(void* new_ptr, int new_size) {
+	ptr = new_ptr;
+	size = new_size;
+	return is_active();
+}
+bool script_memory_buffer::is_active() {return (ptr != nullptr && size > 0); }
 script_memory_buffer* script_memory_buffer::make(asITypeInfo* subtype, void* ptr, int size) { return new script_memory_buffer(subtype, ptr, size); }
 script_memory_buffer* script_memory_buffer::copy(asITypeInfo* subtype, const script_memory_buffer& other) { return new script_memory_buffer(subtype, other.ptr, other.size); }
 bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
@@ -371,7 +377,7 @@ bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
 }
 void script_memory_buffer::angelscript_register(asIScriptEngine* engine) {
 	engine->RegisterObjectType("memory_buffer<class T>", 0, asOBJ_REF | asOBJ_TEMPLATE);
-	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_FACTORY, "memory_buffer<T>@ f(int&in subtype, uint64 ptr, uint64 size)", asFUNCTION(make), asCALL_CDECL);
+	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_FACTORY, "memory_buffer<T>@ f(int&in subtype, uint64 ptr = 0, uint64 size = 0)", asFUNCTION(make), asCALL_CDECL);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_FACTORY, "memory_buffer<T>@ f(int&in subtype, const memory_buffer<T>&in other)", asFUNCTION(copy), asCALL_CDECL);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_ADDREF, "void f()", asMETHOD(script_memory_buffer, AddRef), asCALL_THISCALL);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_RELEASE, "void f()", asMETHOD(script_memory_buffer, Release), asCALL_THISCALL);
@@ -382,7 +388,9 @@ void script_memory_buffer::angelscript_register(asIScriptEngine* engine) {
 	engine->RegisterObjectMethod("memory_buffer<T>", "const T& opIndex(uint64 index) const", asMETHODPR(script_memory_buffer, at, (size_t) const, const void*), asCALL_THISCALL);
 	engine->RegisterObjectMethod("memory_buffer<T>", "array<T>@ opImplConv() const", asMETHOD(script_memory_buffer, to_array), asCALL_THISCALL);
 	engine->RegisterObjectMethod("memory_buffer<T>", "memory_buffer<T>& opAssign(array<T>@ array)", asMETHOD(script_memory_buffer, from_array), asCALL_THISCALL);
+	engine->RegisterObjectMethod("memory_buffer<T>", "bool update(uint64 address = 0, uint64 size = 0)", asMETHOD(script_memory_buffer, update), asCALL_THISCALL);
 	engine->RegisterObjectMethod("memory_buffer<T>", "int get_element_size() const property", asMETHOD(script_memory_buffer, get_element_size), asCALL_THISCALL);
+	engine->RegisterObjectMethod("memory_buffer<T>", "bool get_active() const property", asMETHOD(script_memory_buffer, is_active), asCALL_THISCALL);
 }
 void* string_get_address(std::string& str) {
 	if (str.size() < 1) return nullptr;

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -365,17 +365,17 @@ script_memory_buffer& script_memory_buffer::from_array(CScriptArray* array) {
 int script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
 void script_memory_buffer::make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, int size) { new(mem) script_memory_buffer(subtype, ptr, size); }
 void script_memory_buffer::copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other) { new(mem) script_memory_buffer(other); }
+void script_memory_buffer::destroy(script_memory_buffer* mem) { mem->~script_memory_buffer(); }
 bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
 	if (subtype->GetSubTypeId() & asTYPEID_MASK_OBJECT ) return false;
 	return no_gc = true;
 }
 void script_memory_buffer::angelscript_register(asIScriptEngine* engine) {
-	engine->RegisterObjectType("memory_buffer<class T>", sizeof(script_memory_buffer), asOBJ_REF | asOBJ_TEMPLATE | asGetTypeTraits<script_memory_buffer>());
-	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_FACTORY, "memory_buffer<T>@ f(int&in subtype, uint64 ptr, uint64 size)", asFUNCTION(make), asCALL_CDECL);
-	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_FACTORY, "memory_buffer<T>@ f(int&in subtype, const memory_buffer<T>&in other)", asFUNCTION(copy), asCALL_CDECL);
-	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_ADDREF, "void f()", asMETHOD(script_memory_buffer, AddRef), asCALL_THISCALL);
-	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_RELEASE, "void f()", asMETHOD(script_memory_buffer, Release), asCALL_THISCALL);
+	engine->RegisterObjectType("memory_buffer<class T>", sizeof(script_memory_buffer), asOBJ_VALUE | asOBJ_TEMPLATE | asGetTypeTraits<script_memory_buffer>());
+	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_CONSTRUCT, "void f(int&in subtype, uint64 ptr, uint64 size)", asFUNCTION(make), asCALL_CDECL_OBJFIRST);
+	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_CONSTRUCT, "void f(int&in subtype, const memory_buffer<T>&in other)", asFUNCTION(copy), asCALL_CDECL_OBJFIRST);
 	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_TEMPLATE_CALLBACK, "bool f(int&in subtype, bool&out no_gc)", asFUNCTION(verify), asCALL_CDECL);
+	engine->RegisterObjectBehaviour("memory_buffer<T>", asBEHAVE_DESTRUCT, "void f()", asFUNCTION(destroy), asCALL_CDECL_OBJFIRST);
 	engine->RegisterObjectProperty("memory_buffer<T>", "uint64 address", asOFFSET(script_memory_buffer, ptr));
 	engine->RegisterObjectProperty("memory_buffer<T>", "uint64 size", asOFFSET(script_memory_buffer, size));
 	engine->RegisterObjectMethod("memory_buffer<T>", "T& opIndex(uint64 index)", asMETHODPR(script_memory_buffer, at, (size_t), void*), asCALL_THISCALL);

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -11,6 +11,7 @@
 */
 
 #define NOMINMAX
+#include <cstdint>
 #include <string>
 #include <algorithm>
 #include <vector>
@@ -343,13 +344,13 @@ double parse_double(const std::string& val) {
 
 // Small wrapper which allows statically typed read-write access to an arbitrary memory buffer from scripts.
 // It should be implicitly understood by the scripter that this interface is low level, contains minimal handholding and is not subject to sandboxing!
-const void* script_memory_buffer::at(size_t index) const {
-	if (!ptr) throw std::invalid_argument("memory buffer null pointer access");
+const void* script_memory_buffer::at(uint64_t index) const {
+	if (ptr == nullptr) throw std::invalid_argument("memory buffer null pointer access");
 	int typesize = g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid);
 	if (size && index >= size) throw std::out_of_range("index out of bounds");
 	return (void*)(((char*)ptr) + (index * typesize));
 }
-void* script_memory_buffer::at(size_t index) { return const_cast<void*>(const_cast<const script_memory_buffer*>(this)->at(index)); }
+void* script_memory_buffer::at(uint64_t index) { return const_cast<void*>(const_cast<const script_memory_buffer*>(this)->at(index)); }
 CScriptArray* script_memory_buffer::to_array() const {
 	CScriptArray* array = CScriptArray::Create(g_ScriptEngine->GetTypeInfoByDecl(Poco::format("array<%s>", std::string(g_ScriptEngine->GetTypeDeclaration(subtypeid, false))).c_str()), size);
 	if (!array) return nullptr;
@@ -361,8 +362,8 @@ script_memory_buffer& script_memory_buffer::from_array(CScriptArray* array) {
 	else std::memcpy(ptr, array->GetBuffer(), (array->GetSize() < size? array->GetSize() : size) * g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid));
 	return *this;
 }
-int script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
-void script_memory_buffer::make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, int size) { new(mem) script_memory_buffer(subtype, ptr, size); }
+uint64_t script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
+void script_memory_buffer::make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, uint64_t size) { new(mem) script_memory_buffer(subtype, ptr, size); }
 void script_memory_buffer::copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other) { new(mem) script_memory_buffer(other); }
 void script_memory_buffer::destroy(script_memory_buffer* mem) { mem->~script_memory_buffer(); }
 bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -364,7 +364,7 @@ script_memory_buffer& script_memory_buffer::from_array(CScriptArray* array) {
 }
 int script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
 script_memory_buffer* script_memory_buffer::make(asITypeInfo* subtype, uint64_t ptr, uint64_t size) { return new script_memory_buffer(subtype, ptr, size); }
-script_memory_buffer* script_memory_buffer::copy(asITypeInfo* subtype, const script_memory_buffer& other) { return new script_memory_buffer(other.ptr, other.size); }
+void script_memory_buffer::copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other) { new(mem) script_memory_buffer(other); }
 bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
 	if (subtype->GetSubTypeId() & asTYPEID_MASK_OBJECT ) return false;
 	return no_gc = true;

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -363,6 +363,12 @@ script_memory_buffer& script_memory_buffer::from_array(CScriptArray* array) {
 	return *this;
 }
 uint64_t script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
+bool script_memory_buffer::is_active() { return (ptr != nullptr && size < 1); }
+bool script_memory_buffer::update(void* new_ptr, uint64_t new_size) {
+	ptr = new_ptr;
+	size = new_size;
+	return is_active();
+}
 void script_memory_buffer::make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, uint64_t size) { new(mem) script_memory_buffer(subtype, ptr, size); }
 void script_memory_buffer::copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other) { new(mem) script_memory_buffer(other); }
 void script_memory_buffer::destroy(script_memory_buffer* mem) { mem->~script_memory_buffer(); }
@@ -383,6 +389,8 @@ void script_memory_buffer::angelscript_register(asIScriptEngine* engine) {
 	engine->RegisterObjectMethod("memory_buffer<T>", "array<T>@ opImplConv() const", asMETHOD(script_memory_buffer, to_array), asCALL_THISCALL);
 	engine->RegisterObjectMethod("memory_buffer<T>", "memory_buffer<T>& opAssign(array<T>@ array)", asMETHOD(script_memory_buffer, from_array), asCALL_THISCALL);
 	engine->RegisterObjectMethod("memory_buffer<T>", "int get_element_size() const property", asMETHOD(script_memory_buffer, get_element_size), asCALL_THISCALL);
+	engine->RegisterObjectMethod("memory_buffer<T>", "bool get_active() const property", asMETHOD(script_memory_buffer, is_active), asCALL_THISCALL);
+	engine->RegisterObjectMethod("memory_buffer<T>", "bool update(uint64 address = 0, uint64 size = 0)", asMETHOD(script_memory_buffer, update), asCALL_THISCALL);
 }
 void* string_get_address(std::string& str) {
 	if (str.size() < 1) return nullptr;

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -363,8 +363,8 @@ script_memory_buffer& script_memory_buffer::from_array(CScriptArray* array) {
 	return *this;
 }
 int script_memory_buffer::get_element_size() const {return g_ScriptEngine->GetSizeOfPrimitiveType(subtypeid); }
-script_memory_buffer* script_memory_buffer::make(asITypeInfo* subtype, uint64_t ptr, uint64_t size) { return new script_memory_buffer(subtype, ptr, size); }
-script_memory_buffer* script_memory_buffer::copy(asITypeInfo* subtype, const script_memory_buffer& other) { return new script_memory_buffer(other.ptr, other.size); }
+script_memory_buffer* script_memory_buffer::make(asITypeInfo* subtype, void* ptr, int size) { return new script_memory_buffer(subtype, ptr, size); }
+script_memory_buffer* script_memory_buffer::copy(asITypeInfo* subtype, const script_memory_buffer& other) { return new script_memory_buffer(subtype, other.ptr, other.size); }
 bool script_memory_buffer::verify(asITypeInfo *subtype, bool& no_gc) {
 	if (subtype->GetSubTypeId() & asTYPEID_MASK_OBJECT ) return false;
 	return no_gc = true;

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -49,6 +49,8 @@ struct script_memory_buffer {
 	CScriptArray* to_array() const;
 	script_memory_buffer& from_array(CScriptArray* array);
 	uint64_t get_element_size() const;
+	bool is_active();
+	bool update(void* new_ptr, uint64_t new_size);
 	static void make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, uint64_t size);
 	static void copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other);
 	static void destroy(script_memory_buffer* mem);

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -49,8 +49,8 @@ struct script_memory_buffer {
 	CScriptArray* to_array() const;
 	script_memory_buffer& from_array(CScriptArray* array);
 	int get_element_size() const;
-	static void make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, int size);
-	static void copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other);
+	static script_memory_buffer* make(asITypeInfo* subtype, void* ptr, int size);
+	static script_memory_buffer* copy(asITypeInfo* subtype, const script_memory_buffer& other);
 	static void destroy(script_memory_buffer* mem);
 	static bool verify(asITypeInfo *subtype, bool& no_gc);
 	static script_memory_buffer* create(asITypeInfo* subtype, void* ptr, uint64_t size);

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -38,30 +38,21 @@ public:
 	}
 };
 struct script_memory_buffer {
-	int RefCount;
 	void* ptr;
 	size_t size;
 	asITypeInfo* subtype;
 	int subtypeid;
-	script_memory_buffer(asITypeInfo* subtype, void* ptr, size_t size) : RefCount(1), ptr(ptr), size(size), subtype(subtype), subtypeid(subtype->GetSubTypeId()) {}
+	script_memory_buffer(asITypeInfo* subtype, void* ptr, size_t size) : ptr(ptr), size(size), subtype(subtype), subtypeid(subtype->GetSubTypeId()) {}
 	const void* at(size_t index) const;
 	void* at(size_t index);
 	CScriptArray* to_array() const;
 	script_memory_buffer& from_array(CScriptArray* array);
 	int get_element_size() const;
-	bool update(void* ptr, int size);
-	bool is_active();
-	static script_memory_buffer* make(asITypeInfo* subtype, void* ptr, int size);
-	static script_memory_buffer* copy(asITypeInfo* subtype, const script_memory_buffer& other);
+	static void make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, int size);
+	static void copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other);
 	static void destroy(script_memory_buffer* mem);
 	static bool verify(asITypeInfo *subtype, bool& no_gc);
 	static script_memory_buffer* create(asITypeInfo* subtype, void* ptr, uint64_t size);
 	static void angelscript_register(asIScriptEngine* engine);
-	void AddRef() {
-		asAtomicInc(RefCount);
-	}
-	void Release() {
-		if (asAtomicDec(RefCount) < 1) delete this;
-	}
 };
 void RegisterMiscFunctions(asIScriptEngine* engine);

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -11,6 +11,7 @@
 */
 
 #pragma once
+#include <cstdint>
 #include <string>
 #include <angelscript.h>
 #include "nvgt.h"
@@ -39,16 +40,16 @@ public:
 };
 struct script_memory_buffer {
 	void* ptr;
-	size_t size;
+	uint64_t size;
 	asITypeInfo* subtype;
 	int subtypeid;
-	script_memory_buffer(asITypeInfo* subtype, void* ptr, size_t size) : ptr(ptr), size(size), subtype(subtype), subtypeid(subtype->GetSubTypeId()) {}
-	const void* at(size_t index) const;
-	void* at(size_t index);
+	script_memory_buffer(asITypeInfo* subtype, void* ptr, uint64_t size) : ptr(ptr), size(size), subtype(subtype), subtypeid(subtype->GetSubTypeId()) {}
+	const void* at(uint64_t index) const;
+	void* at(uint64_t index);
 	CScriptArray* to_array() const;
 	script_memory_buffer& from_array(CScriptArray* array);
-	int get_element_size() const;
-	static void make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, int size);
+	uint64_t get_element_size() const;
+	static void make(script_memory_buffer* mem, asITypeInfo* subtype, void* ptr, uint64_t size);
 	static void copy(script_memory_buffer* mem, asITypeInfo* subtype, const script_memory_buffer& other);
 	static void destroy(script_memory_buffer* mem);
 	static bool verify(asITypeInfo *subtype, bool& no_gc);

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -49,6 +49,8 @@ struct script_memory_buffer {
 	CScriptArray* to_array() const;
 	script_memory_buffer& from_array(CScriptArray* array);
 	int get_element_size() const;
+	bool update(void* ptr, int size);
+	bool is_active();
 	static script_memory_buffer* make(asITypeInfo* subtype, void* ptr, int size);
 	static script_memory_buffer* copy(asITypeInfo* subtype, const script_memory_buffer& other);
 	static void destroy(script_memory_buffer* mem);

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -38,11 +38,12 @@ public:
 	}
 };
 struct script_memory_buffer {
+	int RefCount;
 	void* ptr;
 	size_t size;
 	asITypeInfo* subtype;
 	int subtypeid;
-	script_memory_buffer(asITypeInfo* subtype, void* ptr, size_t size) : ptr(ptr), size(size), subtype(subtype), subtypeid(subtype->GetSubTypeId()) {}
+	script_memory_buffer(asITypeInfo* subtype, void* ptr, size_t size) : RefCount(1), ptr(ptr), size(size), subtype(subtype), subtypeid(subtype->GetSubTypeId()) {}
 	const void* at(size_t index) const;
 	void* at(size_t index);
 	CScriptArray* to_array() const;
@@ -54,5 +55,11 @@ struct script_memory_buffer {
 	static bool verify(asITypeInfo *subtype, bool& no_gc);
 	static script_memory_buffer* create(asITypeInfo* subtype, void* ptr, uint64_t size);
 	static void angelscript_register(asIScriptEngine* engine);
+	void AddRef() {
+		asAtomicInc(RefCount);
+	}
+	void Release() {
+		if (asAtomicDec(RefCount) < 1) delete this;
+	}
 };
 void RegisterMiscFunctions(asIScriptEngine* engine);


### PR DESCRIPTION
At the moment, it is not possible to pass memory buffer to other functions because of no default factory.
Either one has to have global or a class property to use outside a function/method.
This PR aims to make this low-level utility highly useful.
1. The object is now a ref type. It will help in having multiple references to single memory buffer for both read/write opperations.
2. Default factory will have ptr and address as 0. It will instantiate the object for later use.
3. A reset method will clear both ptr and size
4. An active boolean property will indicate whether one has initialized the class.
This PR is in draft and should only be merged after confirmation from the author.