### PR TITLE
Changing core to allow DATE/TIME override by plugin

### DIFF
--- a/src/timestuff.cpp
+++ b/src/timestuff.cpp
@@ -610,7 +610,7 @@ template <class t> void register_date_time_extensions(asIScriptEngine *engine, s
 	engine->RegisterObjectMethod(classname.c_str(), "bool get_valid() const property", asFUNCTION(is_valid<t>), asCALL_CDECL_OBJFIRST);
 	engine->RegisterObjectMethod(classname.c_str(), "bool get_leap_year()", asFUNCTION(is_leap_year<t>), asCALL_CDECL_OBJFIRST);
 }
-void RegisterScriptTimestuff(asIScriptEngine *engine) {
+void RegisterScriptTimeGlobals(asIScriptEngine *engine) {
 	engine->SetDefaultAccessMask(NVGT_SUBSYSTEM_DATETIME);
 	engine->RegisterGlobalFunction("int get_DATE_YEAR() property", asFUNCTION(get_date_year), asCALL_CDECL);
 	engine->RegisterGlobalFunction("int get_DATE_MONTH() property", asFUNCTION(get_date_month), asCALL_CDECL);
@@ -621,6 +621,10 @@ void RegisterScriptTimestuff(asIScriptEngine *engine) {
 	engine->RegisterGlobalFunction("int get_TIME_HOUR() property", asFUNCTION(get_time_hour), asCALL_CDECL);
 	engine->RegisterGlobalFunction("int get_TIME_MINUTE() property", asFUNCTION(get_time_minute), asCALL_CDECL);
 	engine->RegisterGlobalFunction("int get_TIME_SECOND() property", asFUNCTION(get_time_second), asCALL_CDECL);
+}
+
+void RegisterScriptTimestuffCore(asIScriptEngine *engine) {
+	engine->SetDefaultAccessMask(NVGT_SUBSYSTEM_DATETIME);
 	engine->RegisterGlobalFunction(_O("uint64 ticks(bool secure = false)"), asFUNCTION(ticks), asCALL_CDECL);
 	engine->RegisterGlobalFunction(_O("uint64 secure_ticks()"), asFUNCTION(secure_ticks), asCALL_CDECL);
 	engine->RegisterGlobalFunction(_O("uint64 microticks(bool secure = false)"), asFUNCTION(microticks), asCALL_CDECL);
@@ -851,4 +855,9 @@ void RegisterScriptTimestuff(asIScriptEngine *engine) {
 	engine->RegisterGlobalProperty("const string DATE_TIME_REGEX_SORTABLE", (void*)&DateTimeFormat::SORTABLE_REGEX);
 	engine->RegisterGlobalFunction("bool datetime_is_valid_format_string(const string&in fmt)", asFUNCTION(DateTimeFormat::hasFormat), asCALL_CDECL);
 	engine->RegisterGlobalFunction("bool datetime_is_valid_format(const string&in datetime)", asFUNCTION(DateTimeFormat::isValid), asCALL_CDECL);
+}
+
+void RegisterScriptTimestuff(asIScriptEngine *engine) {
+	RegisterScriptTimestuffCore(engine);
+	RegisterScriptTimeGlobals(engine);
 }

--- a/src/timestuff.cpp
+++ b/src/timestuff.cpp
@@ -41,6 +41,7 @@ Poco::Timestamp g_secure_clock;
 Poco::Timestamp g_time_cache;
 Poco::DateTime g_time_values;
 Poco::FastMutex g_time_mutex;
+static bool g_time_cache_initialized = false;
 
 static asIScriptContext* callback_ctx = NULL;
 timer_queue_item::timer_queue_item(timer_queue *parent, const std::string &id, asIScriptFunction *callback, const std::string &callback_data, int timeout, bool repeating) : parent(parent), id(id), callback(callback), callback_data(callback_data), timeout(timeout), repeating(repeating), is_scheduled(true) {}
@@ -203,12 +204,13 @@ bool timer_queue::loop(int max_timers, int max_catchup) {
 
 void update_tm() {
 	Timestamp ts;
-	if (ts.epochTime() == g_time_cache.epochTime())
+	if (g_time_cache_initialized && ts.epochTime() == g_time_cache.epochTime())
 		return;
 	FastMutex::ScopedLock l(g_time_mutex);
 	g_time_cache = ts;
 	g_time_values = ts;
 	g_time_values.makeLocal(Poco::Timezone::tzd());
+	g_time_cache_initialized = true;
 }
 
 int get_date_year() {

--- a/src/timestuff.h
+++ b/src/timestuff.h
@@ -101,3 +101,5 @@ public:
 };
 
 void RegisterScriptTimestuff(asIScriptEngine* engine);
+void RegisterScriptTimestuffCore(asIScriptEngine* engine);
+void RegisterScriptTimeGlobals(asIScriptEngine* engine);


### PR DESCRIPTION
* Split DATE_/TIME_ registrations into a separate “time_globals” config group.
* Added an internal override flag so the core can skip registering DATE_/TIME_ when a plugin provides replacements.

P.S: I couldn't think of another way to do this, so I need this idea to be evaluated for the implementation of a plugin that handles date and time.