### PR TITLE
Fix bug in SCRIPT_MAIN_PATH

### DIFF
--- a/src/nvgt.cpp
+++ b/src/nvgt.cpp
@@ -302,7 +302,7 @@ protected:
 			return Application::EXIT_CONFIG;
 		}
 		#endif
-		g_scriptpath = Path(scriptfile).makeParent().toString();
+		g_scriptpath = Path(scriptfile).makeAbsolute().makeParent().toString();
 		setupCommandLineProperty(args, 1);
 		g_command_line_args->InsertAt(0, (void*)&scriptfile);
 		ConfigureEngineOptions(g_ScriptEngine);


### PR DESCRIPTION
SCRIPT_MAIN_PATH could be empty when running a script from the working directory using the command line. This is now fixed.

Fixes #375