### PR TITLE
Implement timer_queue::ticks_to_next_event method from TimerWheel

### DIFF
--- a/src/timestuff.cpp
+++ b/src/timestuff.cpp
@@ -668,6 +668,7 @@ void RegisterScriptTimestuffCore(asIScriptEngine *engine) {
 	engine->RegisterObjectMethod(_O("timer_queue"), _O("string[]@ list_timers()"), asMETHOD(timer_queue, list_timers), asCALL_THISCALL);
 	engine->RegisterObjectMethod(_O("timer_queue"), _O("uint size() const"), asMETHOD(timer_queue, size), asCALL_THISCALL);
 	engine->RegisterObjectMethod(_O("timer_queue"), _O("bool loop(int max_timers = 0, int max_catchup_milliseconds = 100)"), asMETHOD(timer_queue, loop), asCALL_THISCALL);
+	engine->RegisterObjectMethod(_O("timer_queue"), _O("uint64 ticks_to_next_event(uint64 max = 100) const"), asMETHOD(timer_queue, ticks_to_next_event), asCALL_THISCALL);
 	engine->SetDefaultAccessMask(NVGT_SUBSYSTEM_DATETIME);
 	engine->RegisterObjectType(_O("timer"), 0, asOBJ_REF);
 	engine->RegisterObjectBehaviour(_O("timer"), asBEHAVE_FACTORY, _O("timer@ t()"), asFUNCTION(timestuff_factory<timer>), asCALL_CDECL);

--- a/src/timestuff.h
+++ b/src/timestuff.h
@@ -72,6 +72,9 @@ public:
 		return timer_objects.size();
 	}
 	bool loop(int max_timers = 0, int max_catchup = 100);
+	uint64_t ticks_to_next_event(uint64_t max = 100) {
+		return timers.ticks_to_next_event(max);
+	}
 };
 
 class timer : public Poco::RefCountedObject {

--- a/test/quick/test_timer_queue.nvgt
+++ b/test/quick/test_timer_queue.nvgt
@@ -38,5 +38,7 @@ void main() {
 			screen_reader_speak_interrupt(NVDA, timers.size());
 		if (key_pressed(KEY_3))
 			timers.restart("3");
+		if(key_pressed(KEY_RETURN))
+			screen_reader_speak_interrupt(NVDA, timers.ticks_to_next_event(1000));
 	}
 }


### PR DESCRIPTION
This PR adds an angelscript registration of `TimerWheel::ticks_to_next_event()`, which reports the amount of time until the wheel will next fire something, up to a specified maximum.

This function is extremely useful in maintaining optimal tick throughput on a system who's occupancy may vary, particularly when fed into the timing of sleep functions. Sparse event clusters let you sleep longer to reduce CPU usage, with max being the limiter in case you need to maintain minimum tick rate. Dense event clusters let you automatically increase your tick timings to compensate. The combination of these means that a game simulation based on timer queue can scale optimally with the actual timing behavior of the things inside it, without starving execution time from anyone or spinning inefficiently.

The exact signature is `uint64 timer_queue.ticks_to_next_event(uint max = 100);` with 100 chosen to match the default value of maximum catch-up in loop.

A check for pressing enter was also added to the timer queue quick test, which reports the returned value of this function.