### PR TITLE
Fix double free bug crashing tts_voice initialization.

### DIFF
--- a/src/win.cpp
+++ b/src/win.cpp
@@ -77,10 +77,7 @@ string sapi5_engine::get_voice_name(int index) {
 string sapi5_engine::get_voice_language(int index) {
 	if (!inst || index < 0 || index >= get_voice_count()) return "";
 	char *lang = sb_sapi_get_voice_language(inst, index);
-	if (!lang) return "";
-	string result(lang);
-	free(lang);
-	return result;
+	return lang ? string(lang) : "";
 }
 bool sapi5_engine::set_voice(int voice) {
 	if (voice < 0 || voice >= inst->voice_count) return false;


### PR DESCRIPTION
`sapi5_engine::get_voice_language` was freeing the `char*` returned by sapibridge, but that pointer is a pointer directly into sapibridge's own cache. When sapibridge later tried to clean the cache when told to refresh, it tried to free it a second time, which crashed with a heap exception.
Removed the free call and made `sapi5_engine::get_voice_language` mirror `sapi5_engine::get_voice_name` in behavior and function, including the conditional expression on the return.
Confirmed that a SAPI test does actually speak now.
