### PR TITLE
Fix live HTTP audio streaming: stream_url() cannot open an Icecast or radio stream

### DIFF
--- a/src/datastreams.cpp
+++ b/src/datastreams.cpp
@@ -202,15 +202,24 @@ int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 	return static_cast<int>(bytes_read);
 }
 std::streampos prebuffer_istreambuf::seekoff(std::streamoff off, std::ios_base::seekdir dir, std::ios_base::openmode which) {
-	if (dir == std::ios_base::beg && off == 0) return seekpos(0);
-	return -1;
+	// Where the reader actually is. The base class reads ahead of it, and those bytes were counted
+	// into window_pos when readFromDevice handed them over, so they have to come back off.
+	std::streamoff consumed = static_cast<std::streamoff>(window_pos) - (egptr() - gptr());
+	// tellg() arrives here as a seek of zero from the current position. That is a question, not a
+	// move, and this used to answer -1 to it -- so ma_vfs's onTell reported MA_NOT_IMPLEMENTED and
+	// the resource manager abandoned the sound before it ever probed the format.
+	if (dir == std::ios_base::cur && off == 0) return consumed;
+	if (dir == std::ios_base::end) return -1; // the length is unknown, so this genuinely cannot be answered
+	return seekpos(dir == std::ios_base::beg ? off : consumed + off, which);
 }
 std::streampos prebuffer_istreambuf::seekpos(std::streampos pos, std::ios_base::openmode which) {
-	if (pos != 0 || window_closed) return -1;
+	std::streamoff target = pos;
+	if (target < 0 || window_closed) return -1;
 	if (window.empty()) fill_window();
-	window_pos = 0;
+	if (static_cast<std::size_t>(target) > window.size()) return -1; // past what was kept, and the source cannot go back
+	window_pos = static_cast<std::size_t>(target);
 	setg(nullptr, nullptr, nullptr); // drop what the base class had buffered, so it reads through us again
-	return 0;
+	return pos;
 }
 prebuffer_istream::prebuffer_istream(std::istream& source, std::size_t prebuffer_size) : basic_istream(new prebuffer_istreambuf(source, prebuffer_size)) {}
 prebuffer_istream::~prebuffer_istream() { delete rdbuf(); }

--- a/src/datastreams.cpp
+++ b/src/datastreams.cpp
@@ -155,42 +155,49 @@ sdl_file_stream::sdl_file_stream(const std::string& path, const std::string& mod
 sdl_file_stream::sdl_file_stream(SDL_IOStream* io, std::ios::openmode mode) : std::iostream(&_buf) { attach(io, mode); }
 
 // Prebuffered input stream implementation
-prebuffer_istreambuf::prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size) : BasicBufferedStreamBuf(4096, std::ios_base::in), source(&source), prebuffer_size(prebuffer_size), prebuffer_pos(0), prebuffer_discarded(false), owns_source(false) {
+prebuffer_istreambuf::prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size) : BasicBufferedStreamBuf(4096, std::ios_base::in), source(&source), initial_fill(prebuffer_size), window_pos(0), window_closed(false), owns_source(false) {
 	if (!source.good()) throw std::invalid_argument("Source stream is invalid.");
-	prebuffer.reserve(prebuffer_size);
+	window.reserve(WINDOW_CAP); // once, so that appending never reallocates while audio is being served
 }
 prebuffer_istreambuf::~prebuffer_istreambuf() { if (owns_source) delete source; }
 void prebuffer_istreambuf::own_source(bool owns) { owns_source = owns; }
-bool prebuffer_istreambuf::fill_prebuffer() {
-	if (!prebuffer.empty() || prebuffer_discarded) return true;
-	prebuffer.resize(prebuffer_size);
-	source->read(prebuffer.data(), prebuffer_size);
-	std::size_t bytes_read = source->gcount();
-	prebuffer.resize(bytes_read);
-	return bytes_read > 0;
+bool prebuffer_istreambuf::fill_window() {
+	if (!window.empty() || window_closed) return true;
+	window.resize(initial_fill);
+	source->read(window.data(), initial_fill);
+	window.resize(source->gcount());
+	return !window.empty();
 }
 int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 	if (length <= 0) return 0;
 	std::streamsize bytes_read = 0;
-	if (prebuffer.empty() && !prebuffer_discarded) fill_prebuffer();
-	if (!prebuffer_discarded && prebuffer_pos < prebuffer.size()) {
-		std::size_t available_in_prebuffer = prebuffer.size() - prebuffer_pos;
-		std::size_t to_copy = std::min(static_cast<std::size_t>(length), available_in_prebuffer);
-		std::memcpy(buffer, prebuffer.data() + prebuffer_pos, to_copy);
-		prebuffer_pos += to_copy;
+	if (window.empty() && !window_closed) fill_window();
+	// Anything still inside the window is replayed from memory rather than pulled again.
+	if (window_pos < window.size()) {
+		std::size_t to_copy = std::min(static_cast<std::size_t>(length), window.size() - window_pos);
+		std::memcpy(buffer, window.data() + window_pos, to_copy);
+		window_pos += to_copy;
 		buffer += to_copy;
 		length -= to_copy;
 		bytes_read += to_copy;
-		if (prebuffer_pos >= prebuffer.size()) {
-			prebuffer.clear();
-			prebuffer.shrink_to_fit();
-			prebuffer_discarded = true;
-		}
 	}
 	if (length > 0) {
 		source->read(buffer, length);
-		std::streamsize source_bytes_read = source->gcount();
-		bytes_read += source_bytes_read;
+		std::streamsize got = source->gcount();
+		if (!window_closed && got > 0) {
+			// While it is open the window holds every byte read so far, which is what keeps its end
+			// and the source's real position the same place -- replaying up to it then continues
+			// seamlessly into fresh bytes instead of jumping. Once that can no longer hold, the
+			// window is of no further use and says so.
+			if (static_cast<std::size_t>(got) <= WINDOW_CAP - window.size()) window.insert(window.end(), buffer, buffer + got);
+			else {
+				window.clear();
+				window.shrink_to_fit();
+				window_closed = true;
+			}
+		}
+		window_pos += got;
+		bytes_read += got;
 	}
 	return static_cast<int>(bytes_read);
 }
@@ -199,10 +206,10 @@ std::streampos prebuffer_istreambuf::seekoff(std::streamoff off, std::ios_base::
 	return -1;
 }
 std::streampos prebuffer_istreambuf::seekpos(std::streampos pos, std::ios_base::openmode which) {
-	if (pos != 0 || prebuffer_discarded) return -1;
-	if (prebuffer.empty()) fill_prebuffer();
-	prebuffer_pos = 0;
-	setg(nullptr, nullptr, nullptr);
+	if (pos != 0 || window_closed) return -1;
+	if (window.empty()) fill_window();
+	window_pos = 0;
+	setg(nullptr, nullptr, nullptr); // drop what the base class had buffered, so it reads through us again
 	return 0;
 }
 prebuffer_istream::prebuffer_istream(std::istream& source, std::size_t prebuffer_size) : basic_istream(new prebuffer_istreambuf(source, prebuffer_size)) {}

--- a/src/datastreams.cpp
+++ b/src/datastreams.cpp
@@ -185,12 +185,10 @@ int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 		source->read(buffer, length);
 		std::streamsize got = source->gcount();
 		if (!window_closed && got > 0) {
-			// While it is open the window holds every byte read so far, which is what keeps its end
-			// and the source's real position the same place -- replaying up to it then continues
-			// seamlessly into fresh bytes instead of jumping. Once that can no longer hold, the
-			// window is of no further use and says so.
-			if (static_cast<std::size_t>(got) <= WINDOW_CAP - window.size()) window.insert(window.end(), buffer, buffer + got);
-			else {
+			// Keeps every byte read so far so the window's end tracks the source's real position; once it hits WINDOW_CAP it's of no further use, so it's freed immediately rather than held for no reason.
+			std::size_t room = WINDOW_CAP - window.size();
+			window.insert(window.end(), buffer, buffer + std::min(static_cast<std::size_t>(got), room));
+			if (window.size() >= WINDOW_CAP) {
 				window.clear();
 				window.shrink_to_fit();
 				window_closed = true;
@@ -202,13 +200,9 @@ int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 	return static_cast<int>(bytes_read);
 }
 std::streampos prebuffer_istreambuf::seekoff(std::streamoff off, std::ios_base::seekdir dir, std::ios_base::openmode which) {
-	// Where the reader actually is. The base class reads ahead of it, and those bytes were counted
-	// into window_pos when readFromDevice handed them over, so they have to come back off.
+	// Where the reader actually is: the base class reads ahead of it, so those bytes have to come back off window_pos.
 	std::streamoff consumed = static_cast<std::streamoff>(window_pos) - (egptr() - gptr());
-	// tellg() arrives here as a seek of zero from the current position. That is a question, not a
-	// move, and this used to answer -1 to it -- so ma_vfs's onTell reported MA_NOT_IMPLEMENTED and
-	// the resource manager abandoned the sound before it ever probed the format.
-	if (dir == std::ios_base::cur && off == 0) return consumed;
+	if (dir == std::ios_base::cur && off == 0) return consumed; // tellg() arrives here as this; answering it is what lets ma_vfs's onTell succeed
 	if (dir == std::ios_base::end) return -1; // the length is unknown, so this genuinely cannot be answered
 	return seekpos(dir == std::ios_base::beg ? off : consumed + off, which);
 }

--- a/src/datastreams.h
+++ b/src/datastreams.h
@@ -80,14 +80,25 @@ public:
 };
 
 // Prebuffered input stream for unseekable sources like internet radio
+//
+// The rewind window has to outlast format detection. ma_decoder_init identifies a stream by trying
+// each backend in turn -- read a header, rewind to the start, let the next one have a go -- and a
+// socket cannot rewind, so the window is what stands in for that. It used to be thrown away for
+// good the moment it was drained, which happened after about two probes, and every rewind after
+// that failed: no live stream could ever be opened through stream_url, in any format, anywhere.
+//
+// So the window now holds everything handed out, up to WINDOW_CAP, and only stops once the source
+// has genuinely outrun it. Past that a rewind is refused rather than silently mishandled, which is
+// correct: by then playback is linear and nothing asks to seek.
 class prebuffer_istreambuf : public Poco::BasicBufferedStreamBuf<char, std::char_traits<char>> {
+	static const std::size_t WINDOW_CAP = 256 * 1024;
 	std::istream* source;
-	std::vector<char> prebuffer;
-	std::size_t prebuffer_size;
-	std::size_t prebuffer_pos;
-	bool prebuffer_discarded;
+	std::vector<char> window;   // every byte handed out so far, until WINDOW_CAP
+	std::size_t initial_fill;   // pulled up front, both to prime the connection and to seed the window
+	std::size_t window_pos;     // logical read position, which is where the reader believes it is
+	bool window_closed;         // outgrew WINDOW_CAP, so rewinding is no longer possible
 	bool owns_source;
-	bool fill_prebuffer();
+	bool fill_window();
 public:
 	prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size = 1024);
 	~prebuffer_istreambuf();

--- a/src/datastreams.h
+++ b/src/datastreams.h
@@ -79,17 +79,7 @@ public:
 	sdl_file_stream(SDL_IOStream* io, std::ios::openmode mode); // wrap an externally-owned process stdio stream
 };
 
-// Prebuffered input stream for unseekable sources like internet radio
-//
-// The rewind window has to outlast format detection. ma_decoder_init identifies a stream by trying
-// each backend in turn -- read a header, rewind to the start, let the next one have a go -- and a
-// socket cannot rewind, so the window is what stands in for that. It used to be thrown away for
-// good the moment it was drained, which happened after about two probes, and every rewind after
-// that failed: no live stream could ever be opened through stream_url, in any format, anywhere.
-//
-// So the window now holds everything handed out, up to WINDOW_CAP, and only stops once the source
-// has genuinely outrun it. Past that a rewind is refused rather than silently mishandled, which is
-// correct: by then playback is linear and nothing asks to seek.
+// Prebuffered input stream for unseekable sources like internet radio; keeps a rewind window alive up to WINDOW_CAP so ma_decoder_init can probe formats on a socket that cannot itself rewind.
 class prebuffer_istreambuf : public Poco::BasicBufferedStreamBuf<char, std::char_traits<char>> {
 	static const std::size_t WINDOW_CAP = 256 * 1024;
 	std::istream* source;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -720,23 +720,80 @@ audio_ring_buffer* audio_ring_buffer::create(unsigned int channels, unsigned int
 class audio_decoder_impl : public audio_data_source_impl, public virtual audio_decoder {
 	unique_ptr<ma_decoder> decoder;
 	datastream* datastream_ref; // If the user opens a datastream, we must maintain a reference to it encase the user drops their handle.
+	// Rewind window, so that a datastream which cannot seek can still be decoded.
+	//
+	// ma_decoder_init works out a format by trying each backend in turn: read a header, rewind to the
+	// start, let the next one have a go. That is fine for a file and impossible for a socket, and the
+	// seek callback below used to paper over the difference by reporting success for a seekg that had
+	// silently failed. Every backend after the first therefore read from a mangled position, none of
+	// them could initialise, and an Icecast or Shoutcast stream could never be opened at all --
+	// whatever format it was in, and on every platform.
+	//
+	// Everything handed to the decoder is kept here until the window fills, so a rewind inside it is
+	// answered from memory and never reaches the stream. Detection only ever looks at the first few
+	// kilobytes, so the window only has to outlast that; past it playback is linear and seeking is not
+	// wanted anyway. Seekable streams are unaffected: a target outside the window is still passed
+	// through to the stream itself, which is what keeps file decoding behaving exactly as before.
+	struct stream_cursor {
+		static const size_t CAP = 256 * 1024;
+		datastream* ds = nullptr;
+		std::string window;      // every byte served so far, until CAP
+		size_t pos = 0;          // logical read position, which is where the decoder believes it is
+		bool window_closed = false;
+	};
+	unique_ptr<stream_cursor> cursor;
 	static ma_result on_read_datastream(ma_decoder *pDecoder, void *pDst, size_t sizeInBytes, size_t *pBytesRead) {
 		if (pBytesRead) *pBytesRead = 0;
-		datastream* ds = static_cast<datastream*>(pDecoder->pUserData);
-		if (!ds) return MA_ERROR;
-		istream* stream = ds->get_istr();
+		stream_cursor* sc = static_cast<stream_cursor*>(pDecoder->pUserData);
+		if (!sc || !sc->ds) return MA_ERROR;
+		istream* stream = sc->ds->get_istr();
 		if (!stream) return MA_ERROR;
-		if (!stream->good()) return MA_AT_END;
-		stream->read((char *)pDst, sizeInBytes);
-		if (pBytesRead) *pBytesRead = stream->gcount();
-		return MA_SUCCESS;
+		char* out = static_cast<char*>(pDst);
+		size_t total = 0;
+		// Anything still inside the window is replayed from memory rather than pulled again.
+		if (sc->pos < sc->window.size()) {
+			size_t n = std::min(sc->window.size() - sc->pos, sizeInBytes);
+			memcpy(out, sc->window.data() + sc->pos, n);
+			sc->pos += n;
+			out += n;
+			total += n;
+			sizeInBytes -= n;
+		}
+		if (sizeInBytes > 0) {
+			if (!stream->good()) {
+				if (pBytesRead) *pBytesRead = total;
+				return total ? MA_SUCCESS : MA_AT_END;
+			}
+			stream->read(out, sizeInBytes);
+			size_t got = static_cast<size_t>(stream->gcount());
+			// While the window is open it holds every byte read so far, which is what keeps its end
+			// and the stream's real position the same place -- replaying up to it then continues
+			// seamlessly into fresh bytes instead of jumping.
+			if (!sc->window_closed && got) {
+				size_t room = stream_cursor::CAP - sc->window.size();
+				sc->window.append(out, std::min(room, got));
+				if (sc->window.size() >= stream_cursor::CAP) sc->window_closed = true;
+			}
+			sc->pos += got;
+			total += got;
+		}
+		if (pBytesRead) *pBytesRead = total;
+		return total ? MA_SUCCESS : MA_AT_END;
 	}
 	static ma_result on_seek_datastream(ma_decoder *pDecoder, ma_int64 offset, ma_seek_origin origin) {
-		datastream* ds = static_cast<datastream*>(pDecoder->pUserData);
-		if (!ds) return MA_ERROR;
-		istream* stream = ds->get_istr();
+		stream_cursor* sc = static_cast<stream_cursor*>(pDecoder->pUserData);
+		if (!sc || !sc->ds) return MA_ERROR;
+		istream* stream = sc->ds->get_istr();
 		if (!stream) return MA_ERROR;
-		stream->clear();
+		// Where this wants to land, when that can be worked out. A seek from the end means nothing on
+		// a stream of unknown length, so it is left for the stream itself to accept or refuse.
+		ma_int64 target = -1;
+		if (origin == ma_seek_origin_start) target = offset;
+		else if (origin == ma_seek_origin_current) target = static_cast<ma_int64>(sc->pos) + offset;
+		if (target >= 0 && static_cast<size_t>(target) <= sc->window.size()) {
+			sc->pos = static_cast<size_t>(target); // inside the window, so no real seek is needed
+			return MA_SUCCESS;
+		}
 		std::ios_base::seekdir dir;
 		switch (origin) {
 			case ma_seek_origin_start:
@@ -751,15 +808,26 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 			default: // Should never get here.
 				return MA_ERROR;
 		}
+		stream->clear();
 		stream->seekg(offset, dir);
+		if (stream->fail()) {
+			// Genuinely unseekable, and outside what was kept. Say so rather than claiming a seek that
+			// did not happen -- that claim is exactly what made live streams undecodable.
+			stream->clear();
+			return MA_NOT_IMPLEMENTED;
+		}
+		// The stream really moved, so the window no longer describes where the decoder is.
+		sc->pos = static_cast<size_t>(stream->tellg());
+		sc->window.clear();
+		sc->window_closed = true;
 		return MA_SUCCESS;
 	}
 	static ma_result on_tell_datastream(ma_decoder *pDecoder, ma_int64 *pCursor) {
-		datastream* ds = static_cast<datastream*>(pDecoder->pUserData);
-		if (!ds) return MA_ERROR;
-		istream* stream = ds->get_istr();
-		if (!stream) return MA_ERROR;
-		*pCursor = stream->tellg();
+		// The logical position, not the stream's: while the window is being replayed the two differ,
+		// and the decoder's own view is the one that has to be answered.
+		stream_cursor* sc = static_cast<stream_cursor*>(pDecoder->pUserData);
+		if (!sc || !sc->ds) return MA_ERROR;
+		*pCursor = static_cast<ma_int64>(sc->pos);
 		return MA_SUCCESS;
 	}
 	ma_decoder_config decoder_config_init(unsigned int sample_rate, unsigned int channels) {
@@ -792,9 +860,12 @@ public:
 			return false;
 		}
 		ma_decoder_config cfg = decoder_config_init(sample_rate, channels);
+		cursor = make_unique<stream_cursor>();
+		cursor->ds = ds;
 		// Note: We used to pass on_tell_datastream here until miniaudio update Jan 8 2026, if something breaks with raw decoders and end checking, look here.
-		if ((g_soundsystem_last_error = ma_decoder_init(on_read_datastream, on_seek_datastream, ds, &cfg, &*decoder)) != MA_SUCCESS) {
+		if ((g_soundsystem_last_error = ma_decoder_init(on_read_datastream, on_seek_datastream, &*cursor, &cfg, &*decoder)) != MA_SUCCESS) {
 			decoder.reset();
+			cursor.reset();
 			ds->release();
 		} else {
 			datastream_ref = ds;
@@ -811,6 +882,7 @@ public:
 		}
 		if ((g_soundsystem_last_error = ma_decoder_uninit(&*decoder)) != MA_SUCCESS ) return false;
 		decoder.reset();
+		cursor.reset(); // after uninit, since the callbacks read through this
 		return true;
 	}
 	virtual unsigned int get_sample_rate() const override { return decoder? decoder->outputSampleRate : 0; }

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -739,7 +739,11 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		datastream* ds = nullptr;
 		std::string window;      // every byte served so far, until CAP
 		size_t pos = 0;          // logical read position, which is where the decoder believes it is
-		bool window_closed = false;
+		// The window may only answer a seek while it MIRRORS the stream: holding bytes [0, size) and
+		// nothing having moved the stream out from under it. Both of these have to stop that.
+		bool window_full = false;   // hit CAP, so it no longer holds everything read
+		bool window_moved = false;  // a real seek happened, so it no longer starts at byte 0
+		bool mirrors_stream() const { return !window_full && !window_moved; }
 	};
 	unique_ptr<stream_cursor> cursor;
 	static ma_result on_read_datastream(ma_decoder *pDecoder, void *pDst, size_t sizeInBytes, size_t *pBytesRead) {
@@ -751,7 +755,7 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		char* out = static_cast<char*>(pDst);
 		size_t total = 0;
 		// Anything still inside the window is replayed from memory rather than pulled again.
-		if (sc->pos < sc->window.size()) {
+		if (sc->mirrors_stream() && sc->pos < sc->window.size()) {
 			size_t n = std::min(sc->window.size() - sc->pos, sizeInBytes);
 			memcpy(out, sc->window.data() + sc->pos, n);
 			sc->pos += n;
@@ -769,10 +773,10 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 			// While the window is open it holds every byte read so far, which is what keeps its end
 			// and the stream's real position the same place -- replaying up to it then continues
 			// seamlessly into fresh bytes instead of jumping.
-			if (!sc->window_closed && got) {
+			if (sc->mirrors_stream() && got) {
 				size_t room = stream_cursor::CAP - sc->window.size();
 				sc->window.append(out, std::min(room, got));
-				if (sc->window.size() >= stream_cursor::CAP) sc->window_closed = true;
+				if (sc->window.size() >= stream_cursor::CAP) sc->window_full = true;
 			}
 			sc->pos += got;
 			total += got;
@@ -790,7 +794,13 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		ma_int64 target = -1;
 		if (origin == ma_seek_origin_start) target = offset;
 		else if (origin == ma_seek_origin_current) target = static_cast<ma_int64>(sc->pos) + offset;
-		if (target >= 0 && static_cast<size_t>(target) <= sc->window.size()) {
+		// Only while the window mirrors the stream. Testing target <= window.size() on its own is not
+		// enough and was wrong in a way that mattered: after a real seek the window is emptied, and
+		// then a rewind to 0 satisfies 0 <= 0 and reports success without moving the stream, which
+		// leaves the decoder reading from wherever that earlier seek had parked it. A seekable stream
+		// gets a seek to the end to measure its length before anything else, so that is not a corner
+		// case -- it is every in-memory datastream, and it broke all of them.
+		if (sc->mirrors_stream() && target >= 0 && static_cast<size_t>(target) <= sc->window.size()) {
 			sc->pos = static_cast<size_t>(target); // inside the window, so no real seek is needed
 			return MA_SUCCESS;
 		}
@@ -816,10 +826,11 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 			stream->clear();
 			return MA_NOT_IMPLEMENTED;
 		}
-		// The stream really moved, so the window no longer describes where the decoder is.
+		// The stream really moved, so the window no longer describes where the decoder is. From here
+		// the stream answers for itself, which is what it could always do -- it seeks.
 		sc->pos = static_cast<size_t>(stream->tellg());
 		sc->window.clear();
-		sc->window_closed = true;
+		sc->window_moved = true;
 		return MA_SUCCESS;
 	}
 	static ma_result on_tell_datastream(ma_decoder *pDecoder, ma_int64 *pCursor) {

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -720,27 +720,12 @@ audio_ring_buffer* audio_ring_buffer::create(unsigned int channels, unsigned int
 class audio_decoder_impl : public audio_data_source_impl, public virtual audio_decoder {
 	unique_ptr<ma_decoder> decoder;
 	datastream* datastream_ref; // If the user opens a datastream, we must maintain a reference to it encase the user drops their handle.
-	// Rewind window, so that a datastream which cannot seek can still be decoded.
-	//
-	// ma_decoder_init works out a format by trying each backend in turn: read a header, rewind to the
-	// start, let the next one have a go. That is fine for a file and impossible for a socket, and the
-	// seek callback below used to paper over the difference by reporting success for a seekg that had
-	// silently failed. Every backend after the first therefore read from a mangled position, none of
-	// them could initialise, and an Icecast or Shoutcast stream could never be opened at all --
-	// whatever format it was in, and on every platform.
-	//
-	// Everything handed to the decoder is kept here until the window fills, so a rewind inside it is
-	// answered from memory and never reaches the stream. Detection only ever looks at the first few
-	// kilobytes, so the window only has to outlast that; past it playback is linear and seeking is not
-	// wanted anyway. Seekable streams are unaffected: a target outside the window is still passed
-	// through to the stream itself, which is what keeps file decoding behaving exactly as before.
+	// Rewind window so a datastream that can't seek (a live socket) can still be probed and decoded; answers rewinds from memory instead of the stream until the window outgrows CAP or a real seek moves the stream.
 	struct stream_cursor {
 		static const size_t CAP = 256 * 1024;
 		datastream* ds = nullptr;
 		std::string window;      // every byte served so far, until CAP
 		size_t pos = 0;          // logical read position, which is where the decoder believes it is
-		// The window may only answer a seek while it MIRRORS the stream: holding bytes [0, size) and
-		// nothing having moved the stream out from under it. Both of these have to stop that.
 		bool window_full = false;   // hit CAP, so it no longer holds everything read
 		bool window_moved = false;  // a real seek happened, so it no longer starts at byte 0
 		bool mirrors_stream() const { return !window_full && !window_moved; }
@@ -770,13 +755,14 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 			}
 			stream->read(out, sizeInBytes);
 			size_t got = static_cast<size_t>(stream->gcount());
-			// While the window is open it holds every byte read so far, which is what keeps its end
-			// and the stream's real position the same place -- replaying up to it then continues
-			// seamlessly into fresh bytes instead of jumping.
+			// Keeps every byte read so far so the window's end tracks the stream's real position; once full it can never answer a seek again, so it's freed immediately rather than held for the rest of the decoder's life.
 			if (sc->mirrors_stream() && got) {
 				size_t room = stream_cursor::CAP - sc->window.size();
 				sc->window.append(out, std::min(room, got));
-				if (sc->window.size() >= stream_cursor::CAP) sc->window_full = true;
+				if (sc->window.size() >= stream_cursor::CAP) {
+					sc->window_full = true;
+					std::string().swap(sc->window);
+				}
 			}
 			sc->pos += got;
 			total += got;
@@ -789,17 +775,11 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		if (!sc || !sc->ds) return MA_ERROR;
 		istream* stream = sc->ds->get_istr();
 		if (!stream) return MA_ERROR;
-		// Where this wants to land, when that can be worked out. A seek from the end means nothing on
-		// a stream of unknown length, so it is left for the stream itself to accept or refuse.
+		// Where this wants to land, when that can be worked out; a seek from the end is left for the stream to accept or refuse, since a live stream's length is unknown.
 		ma_int64 target = -1;
 		if (origin == ma_seek_origin_start) target = offset;
 		else if (origin == ma_seek_origin_current) target = static_cast<ma_int64>(sc->pos) + offset;
-		// Only while the window mirrors the stream. Testing target <= window.size() on its own is not
-		// enough and was wrong in a way that mattered: after a real seek the window is emptied, and
-		// then a rewind to 0 satisfies 0 <= 0 and reports success without moving the stream, which
-		// leaves the decoder reading from wherever that earlier seek had parked it. A seekable stream
-		// gets a seek to the end to measure its length before anything else, so that is not a corner
-		// case -- it is every in-memory datastream, and it broke all of them.
+		// Only answer from the window while it still mirrors the stream, otherwise a rewind to 0 after a real seek would wrongly report success without moving the stream.
 		if (sc->mirrors_stream() && target >= 0 && static_cast<size_t>(target) <= sc->window.size()) {
 			sc->pos = static_cast<size_t>(target); // inside the window, so no real seek is needed
 			return MA_SUCCESS;
@@ -821,21 +801,17 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		stream->clear();
 		stream->seekg(offset, dir);
 		if (stream->fail()) {
-			// Genuinely unseekable, and outside what was kept. Say so rather than claiming a seek that
-			// did not happen -- that claim is exactly what made live streams undecodable.
-			stream->clear();
+			stream->clear(); // genuinely unseekable and outside what was kept; say so instead of claiming a seek that didn't happen
 			return MA_NOT_IMPLEMENTED;
 		}
-		// The stream really moved, so the window no longer describes where the decoder is. From here
-		// the stream answers for itself, which is what it could always do -- it seeks.
+		// The stream really moved, so the window no longer describes where the decoder is; from here the stream answers for itself. It can never mirror again, so free it rather than just clearing it.
 		sc->pos = static_cast<size_t>(stream->tellg());
-		sc->window.clear();
+		std::string().swap(sc->window);
 		sc->window_moved = true;
 		return MA_SUCCESS;
 	}
 	static ma_result on_tell_datastream(ma_decoder *pDecoder, ma_int64 *pCursor) {
-		// The logical position, not the stream's: while the window is being replayed the two differ,
-		// and the decoder's own view is the one that has to be answered.
+		// The logical position, not the stream's, since the two differ while the window is being replayed.
 		stream_cursor* sc = static_cast<stream_cursor*>(pDecoder->pUserData);
 		if (!sc || !sc->ds) return MA_ERROR;
 		*pCursor = static_cast<ma_int64>(sc->pos);

--- a/src/sound_service.cpp
+++ b/src/sound_service.cpp
@@ -325,11 +325,15 @@ private:
 	static ma_result onRead(ma_vfs *pVFS, ma_vfs_file file, void *pDst, size_t sizeInBytes, size_t *pBytesRead) {
 		if (pBytesRead) *pBytesRead = 0;
 		file_cast(file);
-		if (!stream->good()) return MA_AT_END;
+		// Only a real end of stream stops a read. A failbit left behind by a refused seek must not be
+		// mistaken for one: a live stream refuses every seek it cannot satisfy, and ma_decoder_init
+		// asks for the length before it probes any format, so treating that as the end meant the very
+		// first probe poisoned every read after it and no backend ever saw a byte.
+		if (stream->eof()) return MA_AT_END;
+		if (!stream->good()) stream->clear();
 		stream->read((char *)pDst, sizeInBytes);
 		if (pBytesRead) *pBytesRead = stream->gcount();
-
-		return MA_SUCCESS;
+		return stream->gcount() > 0? MA_SUCCESS : MA_AT_END;
 	}
 	static ma_result onSeek(ma_vfs *pVFS, ma_vfs_file file, ma_int64 offset, ma_seek_origin origin) {
 		file_cast(file);
@@ -349,13 +353,22 @@ private:
 				return MA_ERROR;
 		}
 		stream->seekg(offset, dir);
-		return stream->good()? MA_SUCCESS : MA_NOT_IMPLEMENTED;
+		if (stream->fail()) {
+			stream->clear(); // the reads that follow still need this stream, so leave it usable
+			return MA_NOT_IMPLEMENTED;
+		}
+		return MA_SUCCESS;
 	}
 	static ma_result onTell(ma_vfs *pVFS, ma_vfs_file file, ma_int64 *pCursor) {
 		file_cast(file);
+		stream->clear(); // tellg refuses to answer on a failed stream, and the failure may not be its own
 		ma_int64 result = stream->tellg();
 		*pCursor = result != -1? result : 0;
-		return result != -1? MA_SUCCESS : MA_NOT_IMPLEMENTED;
+		if (result == -1) {
+			stream->clear();
+			return MA_NOT_IMPLEMENTED;
+		}
+		return MA_SUCCESS;
 	}
 	static ma_result onInfo(ma_vfs *pVFS, ma_vfs_file file, ma_file_info *pInfo) {
 		file_cast(file);

--- a/src/sound_service.cpp
+++ b/src/sound_service.cpp
@@ -325,10 +325,7 @@ private:
 	static ma_result onRead(ma_vfs *pVFS, ma_vfs_file file, void *pDst, size_t sizeInBytes, size_t *pBytesRead) {
 		if (pBytesRead) *pBytesRead = 0;
 		file_cast(file);
-		// Only a real end of stream stops a read. A failbit left behind by a refused seek must not be
-		// mistaken for one: a live stream refuses every seek it cannot satisfy, and ma_decoder_init
-		// asks for the length before it probes any format, so treating that as the end meant the very
-		// first probe poisoned every read after it and no backend ever saw a byte.
+		// Only a real end of stream stops a read; a failbit left behind by a refused seek (a live stream refuses seeks it can't satisfy) must not be mistaken for one.
 		if (stream->eof()) return MA_AT_END;
 		if (!stream->good()) stream->clear();
 		stream->read((char *)pDst, sizeInBytes);

--- a/test/interact/stream_url.nvgt
+++ b/test/interact/stream_url.nvgt
@@ -5,7 +5,7 @@
 void main() {
 	show_window("loading...");
 	sound s;
-	if (!s.stream_url("https://nwm.streamguys1.com/ktis-fm")) {
+	if (!s.stream_url("https://radio.weatherusa.net/NWR/KEC65.mp3")) {
 		alert("error", "initialize stream fail");
 		return;
 	}


### PR DESCRIPTION
`sound.stream_url()` cannot open a live HTTP audio stream — an Icecast or Shoutcast radio stream, anything served without a `Content-Length`. Not in a particular format and not on a particular platform: it fails every time, and `audio_decoder.open(datastream)` fails on a socket for a related reason.

`ma_decoder_init` identifies a stream by trying each backend in turn — read a header, rewind to the start, let the next one have a go. A socket cannot rewind. There are four separate places where that goes wrong, and they stack, each one hiding the next.

**1. A refused seek looked like the end of the stream.** This is the one that actually blocks opening. `ma_decoder_init` asks for the length before it probes any format, so the first thing it does to a socket is seek to the end. `sound_service.cpp`'s `onSeek` reported that honestly with `MA_NOT_IMPLEMENTED` but left the istream's failbit set, and `onRead` treated any not-`good()` stream as end-of-file. So one impossible length probe poisoned every read after it and no backend ever saw a byte. `onSeek` now clears the failbit before reporting, `onRead` distinguishes a real `eof()` from an inherited failure, and a read returning nothing says so instead of claiming success with zero bytes. `onTell` no longer inherits an earlier failure either.

**2. The netstream buffer answered -1 to `tellg()`.** `tellg()` reaches a streambuf as `seekoff(0, cur)`, and `prebuffer_istreambuf::seekoff` returned -1 for everything except a rewind to zero — so a position *query* read as a failure, and `ma_vfs`'s `onTell` turned it into `MA_NOT_IMPLEMENTED`. It now answers with the position, taking the base class's read-ahead back off to get where the reader actually is. Seeks are accepted anywhere inside the window; a seek from the end is still refused, which is honest for a stream of unknown length.

**3. The rewind window was one-shot.** `readFromDevice` discarded it the moment it drained, which took two 4096-byte reads, after which every rewind failed. It now holds everything handed out, up to a cap, and refuses a rewind only once the source has genuinely outrun it.

**4. `audio_decoder` on a datastream had no rewind window at all,** and its seek callback returned `MA_SUCCESS` for a `seekg` that had silently failed — so backends after the first read from a mangled position. It now keeps a window of its own and returns `MA_NOT_IMPLEMENTED` when a seek genuinely cannot be served.

### Verification

A standalone harness drives `ma_decoder_init_vfs` through these same `ma_vfs` callbacks over a source whose seeks always fail, which is what a socket is: `MA_INVALID_FILE` before, a decoded 48kHz stereo MP3 after. End to end against a real stream (`https://radio.weatherusa.net/NWR/KEC65.mp3`), `stream_url()` returns false before and plays after. A `file://` URL through the same buffer still streams, so the seekable path is unaffected, and `audio_decoder` on an in-memory datastream still works — that last one matters, because an earlier version of fix 4 broke it: a window emptied by a real seek satisfied `0 <= 0` on a rewind and reported success without moving the stream. Hence the `mirrors_stream()` invariant in commit 2.

Commits 2 and 3 are genuine bugs but were not, on their own, what blocked this stream: the trace shows `ma_decoder_init_vfs` never calling `onTell`, and this stream's detection needs only one rewind at offset 10. I'm including them because a position query answered as a failure and a window discarded after 8KB are wrong regardless, and the resource manager does call `onTell` during playback even if not during init. Fix 1 is the cure.

Note that opening a live stream is only half of it — it still breaks up while playing, because decoding happens on the resource manager's job thread with two one-second pages and no more cushion than that. That's a separate PR, since it adds API rather than fixing a bug, and it builds on this one.

### On authorship

This was written with AI assistance (Claude). I've verified the reasoning and the tests myself, but please review it as such, and if the project would rather not take AI-assisted commits, no hard feelings — the bug analysis above should stand on its own even if you'd prefer to write the fix yourself.
