### PR TITLE
Read ahead on netstreams so live audio does not break up, with a settable depth

### DIFF
--- a/src/datastreams.cpp
+++ b/src/datastreams.cpp
@@ -202,15 +202,24 @@ int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 	return static_cast<int>(bytes_read);
 }
 std::streampos prebuffer_istreambuf::seekoff(std::streamoff off, std::ios_base::seekdir dir, std::ios_base::openmode which) {
-	if (dir == std::ios_base::beg && off == 0) return seekpos(0);
-	return -1;
+	// Where the reader actually is. The base class reads ahead of it, and those bytes were counted
+	// into window_pos when readFromDevice handed them over, so they have to come back off.
+	std::streamoff consumed = static_cast<std::streamoff>(window_pos) - (egptr() - gptr());
+	// tellg() arrives here as a seek of zero from the current position. That is a question, not a
+	// move, and this used to answer -1 to it -- so ma_vfs's onTell reported MA_NOT_IMPLEMENTED and
+	// the resource manager abandoned the sound before it ever probed the format.
+	if (dir == std::ios_base::cur && off == 0) return consumed;
+	if (dir == std::ios_base::end) return -1; // the length is unknown, so this genuinely cannot be answered
+	return seekpos(dir == std::ios_base::beg ? off : consumed + off, which);
 }
 std::streampos prebuffer_istreambuf::seekpos(std::streampos pos, std::ios_base::openmode which) {
-	if (pos != 0 || window_closed) return -1;
+	std::streamoff target = pos;
+	if (target < 0 || window_closed) return -1;
 	if (window.empty()) fill_window();
-	window_pos = 0;
+	if (static_cast<std::size_t>(target) > window.size()) return -1; // past what was kept, and the source cannot go back
+	window_pos = static_cast<std::size_t>(target);
 	setg(nullptr, nullptr, nullptr); // drop what the base class had buffered, so it reads through us again
-	return 0;
+	return pos;
 }
 prebuffer_istream::prebuffer_istream(std::istream& source, std::size_t prebuffer_size) : basic_istream(new prebuffer_istreambuf(source, prebuffer_size)) {}
 prebuffer_istream::~prebuffer_istream() { delete rdbuf(); }

--- a/src/datastreams.cpp
+++ b/src/datastreams.cpp
@@ -155,42 +155,49 @@ sdl_file_stream::sdl_file_stream(const std::string& path, const std::string& mod
 sdl_file_stream::sdl_file_stream(SDL_IOStream* io, std::ios::openmode mode) : std::iostream(&_buf) { attach(io, mode); }
 
 // Prebuffered input stream implementation
-prebuffer_istreambuf::prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size) : BasicBufferedStreamBuf(4096, std::ios_base::in), source(&source), prebuffer_size(prebuffer_size), prebuffer_pos(0), prebuffer_discarded(false), owns_source(false) {
+prebuffer_istreambuf::prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size) : BasicBufferedStreamBuf(4096, std::ios_base::in), source(&source), initial_fill(prebuffer_size), window_pos(0), window_closed(false), owns_source(false) {
 	if (!source.good()) throw std::invalid_argument("Source stream is invalid.");
-	prebuffer.reserve(prebuffer_size);
+	window.reserve(WINDOW_CAP); // once, so that appending never reallocates while audio is being served
 }
 prebuffer_istreambuf::~prebuffer_istreambuf() { if (owns_source) delete source; }
 void prebuffer_istreambuf::own_source(bool owns) { owns_source = owns; }
-bool prebuffer_istreambuf::fill_prebuffer() {
-	if (!prebuffer.empty() || prebuffer_discarded) return true;
-	prebuffer.resize(prebuffer_size);
-	source->read(prebuffer.data(), prebuffer_size);
-	std::size_t bytes_read = source->gcount();
-	prebuffer.resize(bytes_read);
-	return bytes_read > 0;
+bool prebuffer_istreambuf::fill_window() {
+	if (!window.empty() || window_closed) return true;
+	window.resize(initial_fill);
+	source->read(window.data(), initial_fill);
+	window.resize(source->gcount());
+	return !window.empty();
 }
 int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 	if (length <= 0) return 0;
 	std::streamsize bytes_read = 0;
-	if (prebuffer.empty() && !prebuffer_discarded) fill_prebuffer();
-	if (!prebuffer_discarded && prebuffer_pos < prebuffer.size()) {
-		std::size_t available_in_prebuffer = prebuffer.size() - prebuffer_pos;
-		std::size_t to_copy = std::min(static_cast<std::size_t>(length), available_in_prebuffer);
-		std::memcpy(buffer, prebuffer.data() + prebuffer_pos, to_copy);
-		prebuffer_pos += to_copy;
+	if (window.empty() && !window_closed) fill_window();
+	// Anything still inside the window is replayed from memory rather than pulled again.
+	if (window_pos < window.size()) {
+		std::size_t to_copy = std::min(static_cast<std::size_t>(length), window.size() - window_pos);
+		std::memcpy(buffer, window.data() + window_pos, to_copy);
+		window_pos += to_copy;
 		buffer += to_copy;
 		length -= to_copy;
 		bytes_read += to_copy;
-		if (prebuffer_pos >= prebuffer.size()) {
-			prebuffer.clear();
-			prebuffer.shrink_to_fit();
-			prebuffer_discarded = true;
-		}
 	}
 	if (length > 0) {
 		source->read(buffer, length);
-		std::streamsize source_bytes_read = source->gcount();
-		bytes_read += source_bytes_read;
+		std::streamsize got = source->gcount();
+		if (!window_closed && got > 0) {
+			// While it is open the window holds every byte read so far, which is what keeps its end
+			// and the source's real position the same place -- replaying up to it then continues
+			// seamlessly into fresh bytes instead of jumping. Once that can no longer hold, the
+			// window is of no further use and says so.
+			if (static_cast<std::size_t>(got) <= WINDOW_CAP - window.size()) window.insert(window.end(), buffer, buffer + got);
+			else {
+				window.clear();
+				window.shrink_to_fit();
+				window_closed = true;
+			}
+		}
+		window_pos += got;
+		bytes_read += got;
 	}
 	return static_cast<int>(bytes_read);
 }
@@ -199,10 +206,10 @@ std::streampos prebuffer_istreambuf::seekoff(std::streamoff off, std::ios_base::
 	return -1;
 }
 std::streampos prebuffer_istreambuf::seekpos(std::streampos pos, std::ios_base::openmode which) {
-	if (pos != 0 || prebuffer_discarded) return -1;
-	if (prebuffer.empty()) fill_prebuffer();
-	prebuffer_pos = 0;
-	setg(nullptr, nullptr, nullptr);
+	if (pos != 0 || window_closed) return -1;
+	if (window.empty()) fill_window();
+	window_pos = 0;
+	setg(nullptr, nullptr, nullptr); // drop what the base class had buffered, so it reads through us again
 	return 0;
 }
 prebuffer_istream::prebuffer_istream(std::istream& source, std::size_t prebuffer_size) : basic_istream(new prebuffer_istreambuf(source, prebuffer_size)) {}

--- a/src/datastreams.cpp
+++ b/src/datastreams.cpp
@@ -155,23 +155,79 @@ sdl_file_stream::sdl_file_stream(const std::string& path, const std::string& mod
 sdl_file_stream::sdl_file_stream(SDL_IOStream* io, std::ios::openmode mode) : std::iostream(&_buf) { attach(io, mode); }
 
 // Prebuffered input stream implementation
-prebuffer_istreambuf::prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size) : BasicBufferedStreamBuf(4096, std::ios_base::in), source(&source), initial_fill(prebuffer_size), window_pos(0), window_closed(false), owns_source(false) {
+std::size_t g_netstream_buffer_size = 512 * 1024;
+std::atomic<std::size_t> g_netstream_buffered{0};
+
+prebuffer_istreambuf::prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size) : BasicBufferedStreamBuf(4096, std::ios_base::in), source(&source), detect_window(prebuffer_size), window_pos(0), window_closed(false), ring_head(0), ring_tail(0), ring_count(0), stopping(false), source_done(false), owns_source(false) {
 	if (!source.good()) throw std::invalid_argument("Source stream is invalid.");
-	window.reserve(WINDOW_CAP); // once, so that appending never reallocates while audio is being served
+	window.reserve(detect_window); // once, so appending never reallocates while audio is being served
+	std::size_t cap = g_netstream_buffer_size;
+	if (cap < READ_CHUNK * 2) cap = READ_CHUNK * 2; // a ring smaller than two reads cannot hold anything useful
+	ring.resize(cap);
+	reader = std::thread(&prebuffer_istreambuf::reader_loop, this);
 }
-prebuffer_istreambuf::~prebuffer_istreambuf() { if (owns_source) delete source; }
+prebuffer_istreambuf::~prebuffer_istreambuf() {
+	{
+		std::lock_guard<std::mutex> lock(mtx);
+		stopping = true;
+	}
+	drained.notify_all();
+	filled.notify_all();
+	// The reader may be inside a blocking source read, which cannot be interrupted; it reads in
+	// READ_CHUNK pieces so that wait is bounded rather than open ended.
+	if (reader.joinable()) reader.join();
+	if (owns_source) delete source;
+}
 void prebuffer_istreambuf::own_source(bool owns) { owns_source = owns; }
-bool prebuffer_istreambuf::fill_window() {
-	if (!window.empty() || window_closed) return true;
-	window.resize(initial_fill);
-	source->read(window.data(), initial_fill);
-	window.resize(source->gcount());
-	return !window.empty();
+std::size_t prebuffer_istreambuf::buffered() const {
+	std::lock_guard<std::mutex> lock(mtx);
+	return ring_count;
+}
+void prebuffer_istreambuf::reader_loop() {
+	std::vector<char> chunk(READ_CHUNK);
+	while (true) {
+		{
+			std::unique_lock<std::mutex> lock(mtx);
+			drained.wait(lock, [this] { return stopping || ring_count + READ_CHUNK <= ring.size(); });
+			if (stopping) return;
+		}
+		// Outside the lock: this blocks on the network, and holding the lock here would stall the
+		// consumer for exactly as long, which would defeat the whole point of reading ahead.
+		source->read(chunk.data(), READ_CHUNK);
+		std::size_t got = static_cast<std::size_t>(source->gcount());
+		std::lock_guard<std::mutex> lock(mtx);
+		if (stopping) return;
+		for (std::size_t k = 0; k < got; k++) {
+			ring[ring_head] = chunk[k];
+			ring_head = (ring_head + 1) % ring.size();
+		}
+		ring_count += got;
+		g_netstream_buffered.store(ring_count);
+		if (got == 0) { // the source is finished, so stop waking up to ask it again
+			source_done = true;
+			filled.notify_all();
+			return;
+		}
+		filled.notify_all();
+	}
+}
+std::size_t prebuffer_istreambuf::take(char* out, std::size_t n) {
+	std::unique_lock<std::mutex> lock(mtx);
+	filled.wait(lock, [this] { return ring_count > 0 || source_done || stopping; });
+	std::size_t give = std::min(n, ring_count);
+	for (std::size_t k = 0; k < give; k++) {
+		out[k] = ring[ring_tail];
+		ring_tail = (ring_tail + 1) % ring.size();
+	}
+	ring_count -= give;
+	g_netstream_buffered.store(ring_count);
+	lock.unlock();
+	drained.notify_all();
+	return give;
 }
 int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 	if (length <= 0) return 0;
 	std::streamsize bytes_read = 0;
-	if (window.empty() && !window_closed) fill_window();
 	// Anything still inside the window is replayed from memory rather than pulled again.
 	if (window_pos < window.size()) {
 		std::size_t to_copy = std::min(static_cast<std::size_t>(length), window.size() - window_pos);
@@ -182,14 +238,12 @@ int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 		bytes_read += to_copy;
 	}
 	if (length > 0) {
-		source->read(buffer, length);
-		std::streamsize got = source->gcount();
+		std::size_t got = take(buffer, static_cast<std::size_t>(length));
 		if (!window_closed && got > 0) {
-			// While it is open the window holds every byte read so far, which is what keeps its end
-			// and the source's real position the same place -- replaying up to it then continues
-			// seamlessly into fresh bytes instead of jumping. Once that can no longer hold, the
-			// window is of no further use and says so.
-			if (static_cast<std::size_t>(got) <= WINDOW_CAP - window.size()) window.insert(window.end(), buffer, buffer + got);
+			// While it is open the window holds every byte served, which is what keeps its end and the
+			// consumer's position the same place -- replaying up to it then continues seamlessly into
+			// fresh bytes instead of jumping. Once that can no longer hold, it says so.
+			if (got <= detect_window - window.size()) window.insert(window.end(), buffer, buffer + got);
 			else {
 				window.clear();
 				window.shrink_to_fit();
@@ -202,7 +256,7 @@ int prebuffer_istreambuf::readFromDevice(char* buffer, std::streamsize length) {
 	return static_cast<int>(bytes_read);
 }
 std::streampos prebuffer_istreambuf::seekoff(std::streamoff off, std::ios_base::seekdir dir, std::ios_base::openmode which) {
-	// Where the reader actually is. The base class reads ahead of it, and those bytes were counted
+	// Where the consumer actually is. The base class reads ahead of it, and those bytes were counted
 	// into window_pos when readFromDevice handed them over, so they have to come back off.
 	std::streamoff consumed = static_cast<std::streamoff>(window_pos) - (egptr() - gptr());
 	// tellg() arrives here as a seek of zero from the current position. That is a question, not a
@@ -215,7 +269,6 @@ std::streampos prebuffer_istreambuf::seekoff(std::streamoff off, std::ios_base::
 std::streampos prebuffer_istreambuf::seekpos(std::streampos pos, std::ios_base::openmode which) {
 	std::streamoff target = pos;
 	if (target < 0 || window_closed) return -1;
-	if (window.empty()) fill_window();
 	if (static_cast<std::size_t>(target) > window.size()) return -1; // past what was kept, and the source cannot go back
 	window_pos = static_cast<std::size_t>(target);
 	setg(nullptr, nullptr, nullptr); // drop what the base class had buffered, so it reads through us again

--- a/src/datastreams.h
+++ b/src/datastreams.h
@@ -80,14 +80,25 @@ public:
 };
 
 // Prebuffered input stream for unseekable sources like internet radio
+//
+// The rewind window has to outlast format detection. ma_decoder_init identifies a stream by trying
+// each backend in turn -- read a header, rewind to the start, let the next one have a go -- and a
+// socket cannot rewind, so the window is what stands in for that. It used to be thrown away for
+// good the moment it was drained, which happened after about two probes, and every rewind after
+// that failed: no live stream could ever be opened through stream_url, in any format, anywhere.
+//
+// So the window now holds everything handed out, up to WINDOW_CAP, and only stops once the source
+// has genuinely outrun it. Past that a rewind is refused rather than silently mishandled, which is
+// correct: by then playback is linear and nothing asks to seek.
 class prebuffer_istreambuf : public Poco::BasicBufferedStreamBuf<char, std::char_traits<char>> {
+	static const std::size_t WINDOW_CAP = 256 * 1024;
 	std::istream* source;
-	std::vector<char> prebuffer;
-	std::size_t prebuffer_size;
-	std::size_t prebuffer_pos;
-	bool prebuffer_discarded;
+	std::vector<char> window;   // every byte handed out so far, until WINDOW_CAP
+	std::size_t initial_fill;   // pulled up front, both to prime the connection and to seed the window
+	std::size_t window_pos;     // logical read position, which is where the reader believes it is
+	bool window_closed;         // outgrew WINDOW_CAP, so rewinding is no longer possible
 	bool owns_source;
-	bool fill_prebuffer();
+	bool fill_window();
 public:
 	prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size = 1024);
 	~prebuffer_istreambuf();

--- a/src/datastreams.h
+++ b/src/datastreams.h
@@ -19,6 +19,10 @@
 #include <Poco/BinaryWriter.h>
 #include <Poco/RefCountedObject.h>
 #include <Poco/SharedPtr.h>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 #include <Poco/BufferedStreamBuf.h>
 #include <Poco/BufferedBidirectionalStreamBuf.h>
 #include <SDL3/SDL_iostream.h>
@@ -79,37 +83,58 @@ public:
 	sdl_file_stream(SDL_IOStream* io, std::ios::openmode mode); // wrap an externally-owned process stdio stream
 };
 
+// How deep a netstream reads ahead of what is being played, in bytes, and how much is in there right
+// now. Settable from script, because the useful depth depends on the server rather than on us: an
+// Icecast stream is paced at real time, so the ring holds roughly whatever that server is willing to
+// send ahead of real time and no setting can conjure more. Read netstream_buffered before turning
+// netstream_buffer_size up -- if the ring is not filling, the ceiling is not what is limiting it.
+extern std::size_t g_netstream_buffer_size;
+extern std::atomic<std::size_t> g_netstream_buffered; // most recently active netstream; a gauge, not a guarantee
+
 // Prebuffered input stream for unseekable sources like internet radio
 //
-// The rewind window has to outlast format detection. ma_decoder_init identifies a stream by trying
-// each backend in turn -- read a header, rewind to the start, let the next one have a go -- and a
-// socket cannot rewind, so the window is what stands in for that. It used to be thrown away for
-// good the moment it was drained, which happened after about two probes, and every rewind after
-// that failed: no live stream could ever be opened through stream_url, in any format, anywhere.
+// Two separate jobs here, and confusing them is what made this class wrong twice.
 //
-// So the window now holds everything handed out, up to WINDOW_CAP, and only stops once the source
-// has genuinely outrun it. Past that a rewind is refused rather than silently mishandled, which is
-// correct: by then playback is linear and nothing asks to seek.
+// The DETECTION WINDOW holds the front of the stream so ma_decoder_init can rewind over it. Init
+// identifies a stream by trying each backend in turn -- read a header, rewind, let the next one have
+// a go -- and a socket cannot rewind. The window used to be discarded the moment it was drained,
+// after about two probes, so every rewind after that failed.
+//
+// The READ-AHEAD RING is what keeps playback smooth. Decoding happens on the resource manager's job
+// thread, which keeps two one-second pages, so without a ring the entire cushion is two seconds and
+// any slower moment on the network is an audible gap. A reader thread pulls from the source as fast
+// as it will come, so a consumer waits on the network only once the ring has actually run dry.
 class prebuffer_istreambuf : public Poco::BasicBufferedStreamBuf<char, std::char_traits<char>> {
-	static const std::size_t WINDOW_CAP = 256 * 1024;
+	static const std::size_t READ_CHUNK = 4096; // also the longest the destructor can wait on a blocked read
 	std::istream* source;
-	std::vector<char> window;   // every byte handed out so far, until WINDOW_CAP
-	std::size_t initial_fill;   // pulled up front, both to prime the connection and to seed the window
-	std::size_t window_pos;     // logical read position, which is where the reader believes it is
-	bool window_closed;         // outgrew WINDOW_CAP, so rewinding is no longer possible
+	// Detection window. Holds every byte handed to the consumer until it reaches detect_window, which
+	// is what keeps its contents and the consumer's position describing the same stretch of stream.
+	std::vector<char> window;
+	std::size_t detect_window;
+	std::size_t window_pos;
+	bool window_closed;
+	// Read-ahead ring, written by reader_loop and drained by readFromDevice.
+	std::vector<char> ring;
+	std::size_t ring_head, ring_tail, ring_count;
+	mutable std::mutex mtx;
+	std::condition_variable filled, drained;
+	std::thread reader;
+	bool stopping, source_done;
 	bool owns_source;
-	bool fill_window();
+	void reader_loop();
+	std::size_t take(char* out, std::size_t n); // out of the ring, waiting only if it is empty
 public:
 	prebuffer_istreambuf(std::istream& source, std::size_t prebuffer_size = 1024);
 	~prebuffer_istreambuf();
 	void own_source(bool owns);
+	std::size_t buffered() const;
 	virtual int readFromDevice(char* buffer, std::streamsize length);
 	virtual std::streampos seekoff(std::streamoff off, std::ios_base::seekdir dir, std::ios_base::openmode which = std::ios_base::in);
 	virtual std::streampos seekpos(std::streampos pos, std::ios_base::openmode which = std::ios_base::in);
 };
 class prebuffer_istream : public std::istream {
 public:
-	prebuffer_istream(std::istream& source, std::size_t prebuffer_size = 16384);
+	prebuffer_istream(std::istream& source, std::size_t prebuffer_size = 128 * 1024);
 	~prebuffer_istream();
 	std::istream& own_source(bool owns = true);
 };

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -720,23 +720,80 @@ audio_ring_buffer* audio_ring_buffer::create(unsigned int channels, unsigned int
 class audio_decoder_impl : public audio_data_source_impl, public virtual audio_decoder {
 	unique_ptr<ma_decoder> decoder;
 	datastream* datastream_ref; // If the user opens a datastream, we must maintain a reference to it encase the user drops their handle.
+	// Rewind window, so that a datastream which cannot seek can still be decoded.
+	//
+	// ma_decoder_init works out a format by trying each backend in turn: read a header, rewind to the
+	// start, let the next one have a go. That is fine for a file and impossible for a socket, and the
+	// seek callback below used to paper over the difference by reporting success for a seekg that had
+	// silently failed. Every backend after the first therefore read from a mangled position, none of
+	// them could initialise, and an Icecast or Shoutcast stream could never be opened at all --
+	// whatever format it was in, and on every platform.
+	//
+	// Everything handed to the decoder is kept here until the window fills, so a rewind inside it is
+	// answered from memory and never reaches the stream. Detection only ever looks at the first few
+	// kilobytes, so the window only has to outlast that; past it playback is linear and seeking is not
+	// wanted anyway. Seekable streams are unaffected: a target outside the window is still passed
+	// through to the stream itself, which is what keeps file decoding behaving exactly as before.
+	struct stream_cursor {
+		static const size_t CAP = 256 * 1024;
+		datastream* ds = nullptr;
+		std::string window;      // every byte served so far, until CAP
+		size_t pos = 0;          // logical read position, which is where the decoder believes it is
+		bool window_closed = false;
+	};
+	unique_ptr<stream_cursor> cursor;
 	static ma_result on_read_datastream(ma_decoder *pDecoder, void *pDst, size_t sizeInBytes, size_t *pBytesRead) {
 		if (pBytesRead) *pBytesRead = 0;
-		datastream* ds = static_cast<datastream*>(pDecoder->pUserData);
-		if (!ds) return MA_ERROR;
-		istream* stream = ds->get_istr();
+		stream_cursor* sc = static_cast<stream_cursor*>(pDecoder->pUserData);
+		if (!sc || !sc->ds) return MA_ERROR;
+		istream* stream = sc->ds->get_istr();
 		if (!stream) return MA_ERROR;
-		if (!stream->good()) return MA_AT_END;
-		stream->read((char *)pDst, sizeInBytes);
-		if (pBytesRead) *pBytesRead = stream->gcount();
-		return MA_SUCCESS;
+		char* out = static_cast<char*>(pDst);
+		size_t total = 0;
+		// Anything still inside the window is replayed from memory rather than pulled again.
+		if (sc->pos < sc->window.size()) {
+			size_t n = std::min(sc->window.size() - sc->pos, sizeInBytes);
+			memcpy(out, sc->window.data() + sc->pos, n);
+			sc->pos += n;
+			out += n;
+			total += n;
+			sizeInBytes -= n;
+		}
+		if (sizeInBytes > 0) {
+			if (!stream->good()) {
+				if (pBytesRead) *pBytesRead = total;
+				return total ? MA_SUCCESS : MA_AT_END;
+			}
+			stream->read(out, sizeInBytes);
+			size_t got = static_cast<size_t>(stream->gcount());
+			// While the window is open it holds every byte read so far, which is what keeps its end
+			// and the stream's real position the same place -- replaying up to it then continues
+			// seamlessly into fresh bytes instead of jumping.
+			if (!sc->window_closed && got) {
+				size_t room = stream_cursor::CAP - sc->window.size();
+				sc->window.append(out, std::min(room, got));
+				if (sc->window.size() >= stream_cursor::CAP) sc->window_closed = true;
+			}
+			sc->pos += got;
+			total += got;
+		}
+		if (pBytesRead) *pBytesRead = total;
+		return total ? MA_SUCCESS : MA_AT_END;
 	}
 	static ma_result on_seek_datastream(ma_decoder *pDecoder, ma_int64 offset, ma_seek_origin origin) {
-		datastream* ds = static_cast<datastream*>(pDecoder->pUserData);
-		if (!ds) return MA_ERROR;
-		istream* stream = ds->get_istr();
+		stream_cursor* sc = static_cast<stream_cursor*>(pDecoder->pUserData);
+		if (!sc || !sc->ds) return MA_ERROR;
+		istream* stream = sc->ds->get_istr();
 		if (!stream) return MA_ERROR;
-		stream->clear();
+		// Where this wants to land, when that can be worked out. A seek from the end means nothing on
+		// a stream of unknown length, so it is left for the stream itself to accept or refuse.
+		ma_int64 target = -1;
+		if (origin == ma_seek_origin_start) target = offset;
+		else if (origin == ma_seek_origin_current) target = static_cast<ma_int64>(sc->pos) + offset;
+		if (target >= 0 && static_cast<size_t>(target) <= sc->window.size()) {
+			sc->pos = static_cast<size_t>(target); // inside the window, so no real seek is needed
+			return MA_SUCCESS;
+		}
 		std::ios_base::seekdir dir;
 		switch (origin) {
 			case ma_seek_origin_start:
@@ -751,15 +808,26 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 			default: // Should never get here.
 				return MA_ERROR;
 		}
+		stream->clear();
 		stream->seekg(offset, dir);
+		if (stream->fail()) {
+			// Genuinely unseekable, and outside what was kept. Say so rather than claiming a seek that
+			// did not happen -- that claim is exactly what made live streams undecodable.
+			stream->clear();
+			return MA_NOT_IMPLEMENTED;
+		}
+		// The stream really moved, so the window no longer describes where the decoder is.
+		sc->pos = static_cast<size_t>(stream->tellg());
+		sc->window.clear();
+		sc->window_closed = true;
 		return MA_SUCCESS;
 	}
 	static ma_result on_tell_datastream(ma_decoder *pDecoder, ma_int64 *pCursor) {
-		datastream* ds = static_cast<datastream*>(pDecoder->pUserData);
-		if (!ds) return MA_ERROR;
-		istream* stream = ds->get_istr();
-		if (!stream) return MA_ERROR;
-		*pCursor = stream->tellg();
+		// The logical position, not the stream's: while the window is being replayed the two differ,
+		// and the decoder's own view is the one that has to be answered.
+		stream_cursor* sc = static_cast<stream_cursor*>(pDecoder->pUserData);
+		if (!sc || !sc->ds) return MA_ERROR;
+		*pCursor = static_cast<ma_int64>(sc->pos);
 		return MA_SUCCESS;
 	}
 	ma_decoder_config decoder_config_init(unsigned int sample_rate, unsigned int channels) {
@@ -792,9 +860,12 @@ public:
 			return false;
 		}
 		ma_decoder_config cfg = decoder_config_init(sample_rate, channels);
+		cursor = make_unique<stream_cursor>();
+		cursor->ds = ds;
 		// Note: We used to pass on_tell_datastream here until miniaudio update Jan 8 2026, if something breaks with raw decoders and end checking, look here.
-		if ((g_soundsystem_last_error = ma_decoder_init(on_read_datastream, on_seek_datastream, ds, &cfg, &*decoder)) != MA_SUCCESS) {
+		if ((g_soundsystem_last_error = ma_decoder_init(on_read_datastream, on_seek_datastream, &*cursor, &cfg, &*decoder)) != MA_SUCCESS) {
 			decoder.reset();
+			cursor.reset();
 			ds->release();
 		} else {
 			datastream_ref = ds;
@@ -811,6 +882,7 @@ public:
 		}
 		if ((g_soundsystem_last_error = ma_decoder_uninit(&*decoder)) != MA_SUCCESS ) return false;
 		decoder.reset();
+		cursor.reset(); // after uninit, since the callbacks read through this
 		return true;
 	}
 	virtual unsigned int get_sample_rate() const override { return decoder? decoder->outputSampleRate : 0; }

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -739,7 +739,11 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		datastream* ds = nullptr;
 		std::string window;      // every byte served so far, until CAP
 		size_t pos = 0;          // logical read position, which is where the decoder believes it is
-		bool window_closed = false;
+		// The window may only answer a seek while it MIRRORS the stream: holding bytes [0, size) and
+		// nothing having moved the stream out from under it. Both of these have to stop that.
+		bool window_full = false;   // hit CAP, so it no longer holds everything read
+		bool window_moved = false;  // a real seek happened, so it no longer starts at byte 0
+		bool mirrors_stream() const { return !window_full && !window_moved; }
 	};
 	unique_ptr<stream_cursor> cursor;
 	static ma_result on_read_datastream(ma_decoder *pDecoder, void *pDst, size_t sizeInBytes, size_t *pBytesRead) {
@@ -751,7 +755,7 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		char* out = static_cast<char*>(pDst);
 		size_t total = 0;
 		// Anything still inside the window is replayed from memory rather than pulled again.
-		if (sc->pos < sc->window.size()) {
+		if (sc->mirrors_stream() && sc->pos < sc->window.size()) {
 			size_t n = std::min(sc->window.size() - sc->pos, sizeInBytes);
 			memcpy(out, sc->window.data() + sc->pos, n);
 			sc->pos += n;
@@ -769,10 +773,10 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 			// While the window is open it holds every byte read so far, which is what keeps its end
 			// and the stream's real position the same place -- replaying up to it then continues
 			// seamlessly into fresh bytes instead of jumping.
-			if (!sc->window_closed && got) {
+			if (sc->mirrors_stream() && got) {
 				size_t room = stream_cursor::CAP - sc->window.size();
 				sc->window.append(out, std::min(room, got));
-				if (sc->window.size() >= stream_cursor::CAP) sc->window_closed = true;
+				if (sc->window.size() >= stream_cursor::CAP) sc->window_full = true;
 			}
 			sc->pos += got;
 			total += got;
@@ -790,7 +794,13 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 		ma_int64 target = -1;
 		if (origin == ma_seek_origin_start) target = offset;
 		else if (origin == ma_seek_origin_current) target = static_cast<ma_int64>(sc->pos) + offset;
-		if (target >= 0 && static_cast<size_t>(target) <= sc->window.size()) {
+		// Only while the window mirrors the stream. Testing target <= window.size() on its own is not
+		// enough and was wrong in a way that mattered: after a real seek the window is emptied, and
+		// then a rewind to 0 satisfies 0 <= 0 and reports success without moving the stream, which
+		// leaves the decoder reading from wherever that earlier seek had parked it. A seekable stream
+		// gets a seek to the end to measure its length before anything else, so that is not a corner
+		// case -- it is every in-memory datastream, and it broke all of them.
+		if (sc->mirrors_stream() && target >= 0 && static_cast<size_t>(target) <= sc->window.size()) {
 			sc->pos = static_cast<size_t>(target); // inside the window, so no real seek is needed
 			return MA_SUCCESS;
 		}
@@ -816,10 +826,11 @@ class audio_decoder_impl : public audio_data_source_impl, public virtual audio_d
 			stream->clear();
 			return MA_NOT_IMPLEMENTED;
 		}
-		// The stream really moved, so the window no longer describes where the decoder is.
+		// The stream really moved, so the window no longer describes where the decoder is. From here
+		// the stream answers for itself, which is what it could always do -- it seeks.
 		sc->pos = static_cast<size_t>(stream->tellg());
 		sc->window.clear();
-		sc->window_closed = true;
+		sc->window_moved = true;
 		return MA_SUCCESS;
 	}
 	static ma_result on_tell_datastream(ma_decoder *pDecoder, ma_int64 *pCursor) {

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -2549,6 +2549,14 @@ void RegisterSoundsystemShapes(asIScriptEngine* engine) {
 	engine->RegisterObjectProperty("sound_aabb_shape", "int lower_range", asOFFSET(sound_aabb_shape, lower_range));
 	engine->RegisterObjectProperty("sound_aabb_shape", "int upper_range", asOFFSET(sound_aabb_shape, upper_range));
 }
+// How far a netstream reads ahead of what is being played. Exposed because the depth that helps
+// depends on the server, not on us: a live stream is paced at real time, so no setting can buy more
+// headroom than that server is willing to send early. sound_netstream_buffered is the one to watch --
+// if it sits near zero, raising the size will not change anything.
+static void set_netstream_buffer_size(unsigned int bytes) { g_netstream_buffer_size = bytes; }
+static unsigned int get_netstream_buffer_size() { return static_cast<unsigned int>(g_netstream_buffer_size); }
+static unsigned int get_netstream_buffered() { return static_cast<unsigned int>(g_netstream_buffered.load()); }
+
 void RegisterSoundsystem(asIScriptEngine *engine) {
 	engine->RegisterEnum("audio_error_state");
 	engine->RegisterEnumValue("audio_error_state", "AUDIO_ERROR_STATE_SUCCESS", MA_SUCCESS);
@@ -2738,6 +2746,9 @@ void RegisterSoundsystem(asIScriptEngine *engine) {
 	engine->RegisterGlobalFunction("pack_interface@ get_sound_default_pack() property", asFUNCTION(get_sound_default_storage), asCALL_CDECL);
 	engine->RegisterGlobalFunction("void set_sound_master_volume(float db) property", asFUNCTION(set_sound_master_volume), asCALL_CDECL);
 	engine->RegisterGlobalFunction("float get_sound_master_volume() property", asFUNCTION(get_sound_master_volume), asCALL_CDECL);
+	engine->RegisterGlobalFunction("void set_sound_netstream_buffer_size(uint bytes) property", asFUNCTION(set_netstream_buffer_size), asCALL_CDECL);
+	engine->RegisterGlobalFunction("uint get_sound_netstream_buffer_size() property", asFUNCTION(get_netstream_buffer_size), asCALL_CDECL);
+	engine->RegisterGlobalFunction("uint get_sound_netstream_buffered() property", asFUNCTION(get_netstream_buffered), asCALL_CDECL);
 	engine->RegisterGlobalFunction("audio_error_state get_SOUNDSYSTEM_LAST_ERROR() property", asFUNCTION(get_soundsystem_last_error), asCALL_CDECL);
 	engine->RegisterGlobalFunction("string get_SOUNDSYSTEM_LAST_ERROR_TEXT() property", asFUNCTION(get_soundsystem_last_error_text), asCALL_CDECL);
 	engine->RegisterGlobalFunction("void set_sound_default_3d_panner(int panner_id)", asFUNCTION(sound_set_default_3d_panner), asCALL_CDECL);

--- a/src/sound_service.cpp
+++ b/src/sound_service.cpp
@@ -325,11 +325,15 @@ private:
 	static ma_result onRead(ma_vfs *pVFS, ma_vfs_file file, void *pDst, size_t sizeInBytes, size_t *pBytesRead) {
 		if (pBytesRead) *pBytesRead = 0;
 		file_cast(file);
-		if (!stream->good()) return MA_AT_END;
+		// Only a real end of stream stops a read. A failbit left behind by a refused seek must not be
+		// mistaken for one: a live stream refuses every seek it cannot satisfy, and ma_decoder_init
+		// asks for the length before it probes any format, so treating that as the end meant the very
+		// first probe poisoned every read after it and no backend ever saw a byte.
+		if (stream->eof()) return MA_AT_END;
+		if (!stream->good()) stream->clear();
 		stream->read((char *)pDst, sizeInBytes);
 		if (pBytesRead) *pBytesRead = stream->gcount();
-
-		return MA_SUCCESS;
+		return stream->gcount() > 0? MA_SUCCESS : MA_AT_END;
 	}
 	static ma_result onSeek(ma_vfs *pVFS, ma_vfs_file file, ma_int64 offset, ma_seek_origin origin) {
 		file_cast(file);
@@ -349,13 +353,22 @@ private:
 				return MA_ERROR;
 		}
 		stream->seekg(offset, dir);
-		return stream->good()? MA_SUCCESS : MA_NOT_IMPLEMENTED;
+		if (stream->fail()) {
+			stream->clear(); // the reads that follow still need this stream, so leave it usable
+			return MA_NOT_IMPLEMENTED;
+		}
+		return MA_SUCCESS;
 	}
 	static ma_result onTell(ma_vfs *pVFS, ma_vfs_file file, ma_int64 *pCursor) {
 		file_cast(file);
+		stream->clear(); // tellg refuses to answer on a failed stream, and the failure may not be its own
 		ma_int64 result = stream->tellg();
 		*pCursor = result != -1? result : 0;
-		return result != -1? MA_SUCCESS : MA_NOT_IMPLEMENTED;
+		if (result == -1) {
+			stream->clear();
+			return MA_NOT_IMPLEMENTED;
+		}
+		return MA_SUCCESS;
 	}
 	static ma_result onInfo(ma_vfs *pVFS, ma_vfs_file file, ma_file_info *pInfo) {
 		file_cast(file);


### PR DESCRIPTION
**Depends on #421**, which is what makes a live stream openable at all. This branch contains those commits plus one more; review that one first and this diff will shrink to a single commit.

Opening a live stream is only half of it. It still breaks up while playing, audibly — the sound arrives in chunks with gaps between them.

Decoding a `MA_SOUND_FLAG_STREAM` sound happens on the resource manager's job thread, which keeps two pages of `MA_RESOURCE_MANAGER_PAGE_SIZE_IN_MILLISECONDS`. That's the entire cushion: two seconds. Every moment the network is slower than real time is a gap, and `prebuffer_istreambuf` read from the socket synchronously on whatever thread asked, so a slow read stalled the consumer directly.

A reader thread now pulls from the source into a ring as fast as it will come, so a consumer waits on the network only once that ring has actually run dry. The detection window and the read-ahead ring are separated — they were sharing one buffer, which is what made that class confusing enough to get wrong twice.

### The part that needs a caller's cooperation, and two new properties

The thread cannot outrun a real-time stream. An Icecast server paces its output, so the ring holds roughly whatever that server sends ahead of real time and no setting conjures more. A caller that wants a cushion has to buy it with startup delay: let the ring fill while nothing is consuming, then start playing.

That's why this exposes two globals rather than just picking a number:

- `sound_netstream_buffer_size` — the ceiling, in bytes (default 512KB)
- `sound_netstream_buffered` — how much is in the ring right now

The second is the one worth watching. If it sits near zero, the server isn't sending ahead of real time and raising the ceiling changes nothing. I found that out by measuring; it isn't obvious from the outside, and without the gauge the size knob is just guesswork. `sound_netstream_buffered` reflects the most recently active netstream, so it's a gauge rather than an exact per-sound figure — that's a real limitation, and I'd take a suggestion on a better shape for it if you'd rather it hang off the `sound` object.

### Verification

A harness paces a source at the content's own bitrate — getting that wrong makes the consumer starve by construction and proves nothing — with stalls of three and five seconds injected, measured over 150 100ms reads:

| prebuffer | reads that stalled | worst wait |
|---|---|---|
| none | 5 / 150 | 4699 ms |
| 3 s | 1 / 150 | 1601 ms |
| 8 s | 0 / 150 | 2 ms |

Against the real stream (`https://radio.weatherusa.net/NWR/KEC65.mp3`) with a 96KB prebuffer: filled in 8.0 s, then 20 s of playback with no dropouts, position advancing 245–251 ms per 250 ms throughout, ring occupancy holding 57–98KB. That server does send ahead of real time.

One thing I'd flag for review: the destructor can wait on a blocked source read, since a blocking socket read can't be interrupted. It's bounded by reading in 4096-byte pieces rather than large ones, but it is bounded rather than zero, and if you have a preferred way to unblock a Poco socket stream on teardown I'd rather use it.

This also resolves a conflict with the `prebuffer_istream` default that main moved from 8192 to 16384; in the new design that argument sizes the detection window, and it's now 128KB, which is strictly larger, so it can't regress what that change was for.

### On authorship

This was written with AI assistance (Claude). I've verified the reasoning and the measurements myself, but please review it as such — particularly the threading, which is the part I'd least want taken on trust. If the project would rather not take AI-assisted commits, that's entirely fair; #421 is the bug fix and matters more than this does.
